### PR TITLE
Fix typo in bin/benchmark_pydy_codegen.py

### DIFF
--- a/bin/benchmark_pydy_code_gen.py
+++ b/bin/benchmark_pydy_code_gen.py
@@ -11,7 +11,7 @@ from scipy.integrate import odeint
 from numpy import hstack, ones, pi, linspace, array, zeros, zeros_like
 import matplotlib.pyplot as plt
 from pydy.codegen.code import generate_ode_function
-from pydy.codgen.tests.models import \
+from pydy.codegen.tests.models import \
     generate_n_link_pendulum_on_cart_equations_of_motion
 
 


### PR DESCRIPTION
There was a typo in an import statement.
