### PR TITLE
Support for SymPy 0.7.6, fixed #105 and #109.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,16 @@
 language: python
-python:
-  - 2.7
+matrix:
+  include:
+    - python: 2.7
+      env: SYMPY_MASTER="false"
+    - python: 2.7
+      env: SYMPY_MASTER="true"
 virtualenv:
   system_site_packages: true
 before_install:
-  # On Ubuntu 12.04 numpy is at 1.6.1, SciPy is at 0.9.0 and Cython is at
-  # 0.15.1.
+  # On Ubuntu 12.04 (Travis's testing machines) numpy is at 1.6.1, SciPy is at
+  # 0.9.0 and Cython is at 0.15.1.
+  - sudo apt-get update
   - sudo apt-get install -y -qq libatlas-dev python-numpy python-scipy cython
   - sudo apt-get install -y -qq python-coverage
   - sudo apt-get install phantomjs
@@ -13,7 +18,11 @@ before_install:
   # that we test with the system installed version.
   - pip uninstall -y numpy
   - pip install --no-deps Theano==0.6.0
-  - pip install sympy==0.7.4.1
+  - if [[ $SYMPY_MASTER == "false" ]]; then
+      pip install sympy==0.7.4.1;
+    elif [[ $SYMPY_MASTER == "true" ]]; then
+      pip install https://github.com/sympy/sympy/archive/master.zip;
+    fi
   # Note that the `make html` command that runs 'build-sphinx' does not work if
   # Sphinx is installed with 'apt-get install sphinx'. It can't find the
   # numpydoc extension if it is. It must be bypassing virtualenv to the system

--- a/pydy/codegen/tests/expected_cython/desired_mass_forcing_c.c
+++ b/pydy/codegen/tests/expected_cython/desired_mass_forcing_c.c
@@ -1,7 +1,7 @@
 #include <math.h>
 #include "desired_mass_forcing_c.h"
 
-void mass_forcing(double constants[4], // constants = [k0, m0, g, c0]
+void mass_forcing(double constants[4], // constants = [c0, g, k0, m0]
                   double coordinates[1], // coordinates = [x0]
                   double speeds[1], // speeds = [v0]
                   double specified[1], // specified = [f0]
@@ -15,9 +15,9 @@ void mass_forcing(double constants[4], // constants = [k0, m0, g, c0]
     mass_matrix[0] = 1;
     mass_matrix[1] = 0;
     mass_matrix[2] = 0;
-    mass_matrix[3] = constants[1];
+    mass_matrix[3] = constants[3];
 
     // forcing vector
     forcing_vector[0] = z_0;
-    forcing_vector[1] = -constants[3]*z_0 + constants[2]*constants[1] - constants[0]*coordinates[0] + specified[0];
+    forcing_vector[1] = -constants[0]*z_0 + constants[1]*constants[3] - constants[2]*coordinates[0] + specified[0];
 }

--- a/pydy/codegen/tests/expected_cython/desired_mass_forcing_c.h
+++ b/pydy/codegen/tests/expected_cython/desired_mass_forcing_c.h
@@ -1,4 +1,4 @@
-void mass_forcing(double constants[4], // constants = [k0, m0, g, c0]
+void mass_forcing(double constants[4], // constants = [c0, g, k0, m0]
                   double coordinates[1], // coordinates = [x0]
                   double speeds[1], // speeds = [v0]
                   double specified[1], // specified = [f0]

--- a/pydy/codegen/tests/test_code.py
+++ b/pydy/codegen/tests/test_code.py
@@ -24,7 +24,11 @@ class TestCythonGenerator():
     def test_write_cython_code(self):
 
         sys = multi_mass_spring_damper(1, True, True)
-        args = sys._args_for_gen_ode_func()
+        args = list(sys._args_for_gen_ode_func())
+        # Depending on the SymPy version, the list of constants may be
+        # ordered differently. This makes it hard to test against the
+        # pregenerated files. So order the list symbols.
+        args[2] = list(sm.ordered(args[2]))
         kwargs = sys._kwargs_for_gen_ode_func()
 
         generator = CythonGenerator(self.prefix, *args, **kwargs)

--- a/pydy/tests/test_models.py
+++ b/pydy/tests/test_models.py
@@ -1,6 +1,9 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
+# standard libraries
+from collections import Counter
+
 # external libraries
 import sympy as sm
 import sympy.physics.mechanics as me
@@ -16,7 +19,7 @@ def test_multi_mass_spring_damper():
 
     sys = multi_mass_spring_damper()
 
-    assert sys.constants_symbols == [k0, c0, m0]
+    assert Counter(sys.constants_symbols) == Counter([k0, c0, m0])
     assert sys.specifieds_symbols == list()
     assert sys.coordinates == [x0]
     assert sys.speeds == [v0]
@@ -40,7 +43,7 @@ def test_multi_mass_spring_damper_with_forces():
     sys = multi_mass_spring_damper(apply_gravity=True,
                                    apply_external_forces=True)
 
-    assert sys.constants_symbols == [k0, m0, g, c0]
+    assert Counter(sys.constants_symbols) == Counter([k0, m0, g, c0])
     assert sys.specifieds_symbols == [f0]
     assert sys.coordinates == [x0]
     assert sys.speeds == [v0]
@@ -63,7 +66,8 @@ def test_multi_mass_spring_damper_double():
 
     sys = multi_mass_spring_damper(2, True, True)
 
-    assert sys.constants_symbols == [c1, m1, k0, c0, k1, g, m0]
+    assert Counter(sys.constants_symbols) == \
+        Counter([c1, m1, k0, c0, k1, g, m0])
     assert sys.specifieds_symbols == [f0, f1]
     assert sys.coordinates == [x0, x1]
     assert sys.speeds == [v0, v1]

--- a/pydy/utils.py
+++ b/pydy/utils.py
@@ -1,0 +1,12 @@
+#!/usr/bin/env python
+
+from pkg_resources import parse_version
+import sympy as sm
+
+SYMPY_VERSION = sm.__version__
+
+
+def sympy_equal_to_or_newer_than(version):
+    """Returns true if the installed version of SymPy is equal to or newer
+    than the provided version string."""
+    return cmp(parse_version(SYMPY_VERSION), parse_version(version)) > -1


### PR DESCRIPTION
- Modified System with conditionals to check for pre and post SymPy 0.7.6 and
  then use the appropriate methods on KanesMethod.
- Added matrix of tests for both SymPy 0.7.4.1 and SymPy HEAD of master to
  Travis.
- Cleaned up some docs in system.py.
- Fixed tests so that order of symbols is ignored.