### PR TITLE
Modified code to remove all instances of Mesh.

### DIFF
--- a/docs/viz/pymodules/shapes.rst
+++ b/docs/viz/pymodules/shapes.rst
@@ -79,8 +79,3 @@ Tube
 .. autoclass:: pydy.viz.shapes.Tube
    :members:
 
-Mesh
-^^^^
-
-.. autoclass:: pydy.viz.shapes.Mesh
-   :members:

--- a/pydy/viz/shapes.py
+++ b/pydy/viz/shapes.py
@@ -12,8 +12,7 @@ __all__ = ['Shape',
            'Icosahedron',
            'Torus',
            'TorusKnot',
-           'Tube',
-           'Mesh']
+           'Tube']
 
 
 import numpy as np
@@ -72,7 +71,7 @@ Materials = ["default", "CHECKERBOARD", "METAL", "DIRT", "FOIL", "WATER", "GRASS
 
 class Shape(object):
     """Instantiates a shape. This is primarily used as a superclass for more
-    specific shapes like Mesh, Cylinder, Sphere etc.
+    specific shapes like Cube, Cylinder, Sphere etc.
 
     Shapes must be associated with a reference frame and a point using the
     VisualizationFrame class.
@@ -106,7 +105,6 @@ class Shape(object):
     'red'
 
     """
-    #TODO Need to modify the default material
     def __init__(self, name='unnamed', color='grey', material="default"):
         self.name = name
         if not isinstance(color, str) \
@@ -805,54 +803,3 @@ class Tube(Shape):
         self._points = np.asarray(new_points)
 
 
-class Mesh(Shape):
-    """Instantiates a general mesh surface from the given points.
-
-    Parameters
-    ==========
-    points : array_like, shape(n, 3)
-        n sets of (x, y, z) coordinates that describe a surface mesh.
-
-    Examples
-    ========
-
-    >>> from pydy.viz.shapes import Mesh
-    >>> points = [[1.0, 2.0, 1.0], [2.0, 1.0, 1.0], [2.0, 3.0, 4.0]]
-    >>> s = Mesh(points)
-    >>> s.name
-    'unnamed'
-    >>> s.color
-    'grey'
-    >>> s.points
-    [[1.0, 2.0, 1.0], [2.0, 1.0, 1.0], [2.0, 3.0, 4.0]]
-    >>> s.name = 'my-shape1'
-    >>> s.name
-    'my-shape1'
-    >>> s.color = 'blue'
-    >>> s.color
-    'blue'
-    >>> s.points = [[2.0, 1.0, 4.0], [1.0, 2.0, 4.0], [2.0, 3.0, 1.0], [1.0, 1.0, 3.0]]
-    >>> s.points
-    [[2.0, 1.0, 4.0], [1.0, 2.0, 4.0], [2.0, 3.0, 1.0], [1.0, 1.0, 3.0]]
-    >>> a = Mesh(points, name='my-shape2', color='red')
-    >>> a.name
-    'my-shape2'
-    >>> a.color
-    'red'
-    >>> a.points
-    [[1.0, 2.0, 1.0], [2.0, 1.0, 1.0], [2.0, 3.0, 4.0]]
-
-    """
-
-    def __init__(self, points, **kwargs):
-        super(Mesh, self).__init__(**kwargs)
-        self.geometry_attrs += ['points']
-        self.points = points
-
-    @property
-    def points(self):
-        return self._points
-
-    @points.setter
-    def points(self, new_points):
-        self._points = np.asarray(new_points)

--- a/pydy/viz/static/js/dyviz/param_editor.js
+++ b/pydy/viz/static/js/dyviz/param_editor.js
@@ -122,9 +122,6 @@ DynamicsVisualizer.ParamEditor = Object.extend(DynamicsVisualizer, {
                 updated_object.length = jQuery("#_length").val()
                 break;
 
-            // TODO for Mesh..
-
-
         }
 
         jQuery.extend(true,self.model.objects[int_id],updated_object);

--- a/pydy/viz/static/js/dyviz/scene.js
+++ b/pydy/viz/static/js/dyviz/scene.js
@@ -157,10 +157,6 @@ DynamicsVisualizer.Scene = Object.extend(DynamicsVisualizer, {
 
         switch(type) {
 
-            case "Mesh":
-                //TODO
-                break;
-
             case "Cube":
                 var geometry = new THREE.CubeGeometry(
                                   object.length,

--- a/pydy/viz/tests/test_shapes.py
+++ b/pydy/viz/tests/test_shapes.py
@@ -253,56 +253,6 @@ def test_circle():
                 'Circle unnamed color:gold material:default radius:10.0'
     assert circle.__repr__() == 'Circle'
 
-
-def test_mesh():
-    point_list = [[2., 3., 1.], [4., 6., 2.],
-                  [5., 3., 1.], [5., 3., 6.],
-                  [2., 8., 4.], [7., 4., 1.]]
-
-    mesh_shape = Mesh(point_list, name='mesh', color='green')
-    assert mesh_shape.name == 'mesh'
-    #TODO Handle these long strings
-    assert mesh_shape.__str__() == \
-        'Mesh mesh color:green material:default points:[[ 2.  3.  1.]\n [ 4.  6.  2.]\n [ 5.  3.  1.]\n [ 5.  3.  6.]\n [ 2.  8.  4.]\n [ 7.  4.  1.]]'
-
-    assert mesh_shape.__repr__() == 'Mesh'
-    assert_allclose(mesh_shape.points, point_list)
-    assert mesh_shape.color == 'green'
-
-    mesh_shape.name = 'mesh1'
-    assert mesh_shape.name == 'mesh1'
-
-    new_point_list = [[3., 4., 12.],
-                      [2., 4., 4.],
-                      [3., 2., 41.],
-                      [2., 5., 4.]]
-    mesh_shape.points = new_point_list
-    assert_allclose(mesh_shape.points, new_point_list)
-
-    mesh_shape.color = 'pink'
-    assert mesh_shape.color == 'pink'
-
-    actual = mesh_shape.generate_dict()
-
-    expected = {"color": "pink",
-                "type": "Mesh",
-                "name": "mesh1",
-                "points": np.asarray(new_point_list),
-                "material":  "default"}
-
-    for key in ['color', 'type', 'name']:
-        actual[key] == expected[key]
-    assert_allclose(actual['points'], expected['points'])
-
-    assert isinstance(mesh_shape, Shape)
-
-    mesh_shape_ = Mesh(points=point_list, color='green')
-    assert mesh_shape_.name == 'unnamed'
-    assert mesh_shape_.__str__() == \
-        'Mesh unnamed color:green material:default points:[[ 2.  3.  1.]\n [ 4.  6.  2.]\n [ 5.  3.  1.]\n [ 5.  3.  6.]\n [ 2.  8.  4.]\n [ 7.  4.  1.]]'
-    assert mesh_shape_.__repr__() == 'Mesh'
-
-
 def test_plane():
     plane = Plane(10.0, 20.0, name='plane', color='indigo')
     assert plane.name == 'plane'


### PR DESCRIPTION
This PR removes any partial implementations of Mesh Shape present in the PyDy Code.

Fixes issue #21.

- [ ] There are no merge conflicts.
- [ ] If there is a related issue, a reference to that issue is in the
  commit message.
- [x] Unit tests have been added for the bug. (Please reference the issue #
  in the unit test.)
- [ ] The tests pass both locally (run `nosetests`) and on Travis CI.
- [x] The code follows PEP8 guidelines. (use a linter, e.g.
  [pylint](http://www.pylint.org), to check your code)
- [ ] The bug fix is documented in the [Release
  Notes](https://github.com/pydy/pydy#release-notes).
- [ ] The code is backwards compatible. (All public methods/classes must
  follow deprecation cycles.)
- [ ] Create a WIP PR with the mesh code.
- [ ] All reviewer comments have been addressed.