### PR TITLE
setuptools >= 8 is now required and used on Travis with pip >=6.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,9 +18,6 @@ install:
   - sudo apt-get install -y -qq python-numpy python-scipy cython
   - sudo apt-get install -y -qq python-coverage
   - sudo apt-get install -y -qq phantomjs
-  # SymPy's development version identifiers are not PEP 440 compliant and
-  # Travis now uses pip>6 setuptools>8, so we roll these back.
-  - pip install "pip<6" "setuptools<8"
   # Theano may try to install SciPy from source if the --no-deps flags isn't
   # there.
   - pip install --no-deps Theano==0.6.0
@@ -38,7 +35,6 @@ install:
   # Install PEP 8 linters (flake8 is like pep8 but also reports unused imports)
   - pip install flake8
 before_script:
-  - python -c "import setuptools; print(setuptools.__version__)"
   - pip --version
   - pip freeze
 script:

--- a/README.rst
+++ b/README.rst
@@ -352,10 +352,13 @@ User Facing
 Development
 ~~~~~~~~~~~
 
+- When using older SymPy development versions with non-PEP440 compliant version
+  identifiers, setuptools < 8 is required. [PR `#166`_]
 - Development version numbers are now PEP 440 compliant. [PR `#141`_]
 - Introduced pull request checklists and CONTRIBUTING file. [PR `#146`_]
 - Introduced light code linting into Travis. [PR `#148`_]
 
+.. _#166: https://github.com/pydy/pydy/pull/166
 .. _#141: https://github.com/pydy/pydy/pull/141
 .. _#146: https://github.com/pydy/pydy/pull/146
 .. _#148: https://github.com/pydy/pydy/pull/148

--- a/pydy/tests/test_utils.py
+++ b/pydy/tests/test_utils.py
@@ -1,12 +1,20 @@
 #!/usr/bin/env python
 
+from pkg_resources import parse_version
+from setuptools import __version__ as SETUPTOOLS_VERSION
+from nose.tools import assert_raises
+
 from ..utils import sympy_equal_to_or_newer_than
 
 
 def test_sympy_equal_to_or_newer_than():
 
-    assert sympy_equal_to_or_newer_than('0.7.6-git', '0.7.6-git')
-    assert sympy_equal_to_or_newer_than('0.7.6', '0.7.6-git')
-    assert sympy_equal_to_or_newer_than('0.7.5', '0.7.6-git')
-    assert sympy_equal_to_or_newer_than('0.6.5', '0.7.6-git')
-    assert not sympy_equal_to_or_newer_than('0.7.7', '0.7.6-git')
+    # sympy_equal_to_or_newer_than(version, installed_version)
+    assert sympy_equal_to_or_newer_than('0.7.6.dev', '0.7.6.dev')
+    assert not sympy_equal_to_or_newer_than('0.7.6', '0.7.6.dev')
+    assert sympy_equal_to_or_newer_than('0.7.5', '0.7.6.dev')
+    assert sympy_equal_to_or_newer_than('0.6.5', '0.7.6.dev')
+    assert not sympy_equal_to_or_newer_than('0.7.7', '0.7.6.dev')
+    if parse_version(SETUPTOOLS_VERSION) >= parse_version('8.0'):
+        with assert_raises(ValueError):
+            sympy_equal_to_or_newer_than('0.7.7', '0.7.6-git')

--- a/pydy/utils.py
+++ b/pydy/utils.py
@@ -3,6 +3,7 @@
 import textwrap
 
 from pkg_resources import parse_version
+from setuptools import __version__ as SETUPTOOLS_VERSION
 import sympy as sm
 from sympy.core.function import AppliedUndef
 from sympy.utilities.iterables import iterable
@@ -14,10 +15,20 @@ SYMPY_VERSION = sm.__version__
 def sympy_equal_to_or_newer_than(version, installed_version=None):
     """Returns true if the installed version of SymPy is equal to or newer
     than the provided version string."""
+
     if installed_version is None:
         v = SYMPY_VERSION
     else:
         v = installed_version
+
+    if v.endswith('-git') and \
+            parse_version(SETUPTOOLS_VERSION) >= parse_version('8.0'):
+
+        msg = ('You are using an older development version of SymPy with a '
+               'non-PEP440 compliant version number: {}. Please install '
+               'setuptools < 8.0 or a newer development version of SymPy.')
+        raise ValueError(msg.format(v))
+
     return cmp(parse_version(v), parse_version(version)) > -1
 
 


### PR DESCRIPTION
Fixes issue #120.

If development versions of SymPy are used to test PyDy one must now use new
SymPy versions with PEP440 compliant version identifiers. Older SymPy dev
version numbers that end in `-git` will now fail with a ValueError unless
setuptools < 8.0 are used.

- [x] There are no merge conflicts.
- [x] If there is a related issue, a reference to that issue is in the
  commit message.
- [x] Unit tests have been added for the bug. (Please reference the issue #
  in the unit test.)
- [x] The tests pass both locally (run `nosetests`) and on Travis CI.
- [x] The code follows PEP8 guidelines. (use a linter, e.g.
  [pylint](http://www.pylint.org), to check your code)
- [x] The bug fix is documented in the [Release
  Notes](https://github.com/pydy/pydy#release-notes).
- [x] The code is backwards compatible. (All public methods/classes must
  follow deprecation cycles.)
- [x] All reviewer comments have been addressed.