### PR TITLE
Orders the constants in the code gen tests.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,11 @@ language: python
 matrix:
   include:
     - python: 2.7
-      env: SYMPY_MASTER="false"
+      env: SYMPY_VERSION="oldest"
     - python: 2.7
-      env: SYMPY_MASTER="true"
+      env: SYMPY_VERSION="latest"
+    - python: 2.7
+      env: SYMPY_VERSION="master"
 virtualenv:
   system_site_packages: true
 before_install:
@@ -21,9 +23,11 @@ install:
   # Theano may try to install SciPy from source if the --no-deps flags isn't
   # there.
   - pip install --no-deps Theano==0.6.0
-  - if [[ $SYMPY_MASTER == "false" ]]; then
+  - if [[ $SYMPY_VERSION == "oldest" ]]; then
       pip install sympy==0.7.4.1;
-    elif [[ $SYMPY_MASTER == "true" ]]; then
+    elif [[ $SYMPY_VERSION == "latest" ]]; then
+      pip install sympy;
+    elif [[ $SYMPY_VERSION == "master" ]]; then
       pip install https://github.com/sympy/sympy/archive/master.zip;
     fi
   - pip install -U nose

--- a/pydy/codegen/tests/test_ode_function_generator.py
+++ b/pydy/codegen/tests/test_ode_function_generator.py
@@ -282,8 +282,8 @@ class TestODEFunctionGeneratorSubclasses(object):
         # There are eight constants and four specified inputs available.
         sys = models.n_link_pendulum_on_cart(3, True, True)
         right_hand_side = sys.eom_method.rhs()
-        constants = sys.constants_symbols
-        specifieds = sys.specifieds_symbols
+        constants = list(sm.ordered(sys.constants_symbols))
+        specifieds = list(sm.ordered(sys.specifieds_symbols))
 
         constants_arg_types = [None, 'array', 'dictionary']
         specifieds_arg_types = [None, 'array', 'function', 'dictionary']
@@ -320,7 +320,7 @@ class TestODEFunctionGeneratorSubclasses(object):
                 g = LambdifyODEFunctionGenerator(right_hand_side,
                                                  sys.coordinates,
                                                  sys.speeds,
-                                                 sys.constants_symbols,
+                                                 constants,
                                                  specifieds=specifieds,
                                                  constants_arg_type=p_arg_type,
                                                  specifieds_arg_type=r_arg_type)
@@ -338,7 +338,7 @@ class TestODEFunctionGeneratorSubclasses(object):
         # Now make sure it all works with specifieds=None
         sys = models.n_link_pendulum_on_cart(3, False, False)
         right_hand_side = sys.eom_method.rhs()
-        constants = sys.constants_symbols
+        constants = list(sm.ordered(sys.constants_symbols))
 
         del last_xdot
 
@@ -348,7 +348,7 @@ class TestODEFunctionGeneratorSubclasses(object):
                 g = LambdifyODEFunctionGenerator(right_hand_side,
                                                  sys.coordinates,
                                                  sys.speeds,
-                                                 sys.constants_symbols,
+                                                 constants,
                                                  constants_arg_type=p_arg_type,
                                                  specifieds_arg_type=r_arg_type)
 


### PR DESCRIPTION
Different versions of SymPy spit out different orders so this is inplace to make sure the tests pass on all SymPy versions. Also introduced a new Travis test matrix entry for the latest SymPy version.

Fixes #162 

- [x] There are no merge conflicts.
- [x] If there is a related issue, a reference to that issue is in the
  commit message.
- [x] Unit tests have been added for the bug. (Please reference the issue #
  in the unit test.)
- [x] The tests pass both locally (run `nosetests`) and on Travis CI.
- [x] The code follows PEP8 guidelines. (use a linter, e.g.
  [pylint](http://www.pylint.org), to check your code)
- [x] The bug fix is documented in the [Release
  Notes](https://github.com/pydy/pydy#release-notes).
- [x] The code is backwards compatible. (All public methods/classes must
  follow deprecation cycles.)
- [x] All reviewer comments have been addressed.