### PR TITLE
Correct __init__ docstring added for the Cython/Theano ODE generators.

### DIFF
--- a/pydy/codegen/ode_function_generators.py
+++ b/pydy/codegen/ode_function_generators.py
@@ -752,6 +752,8 @@ class CythonODEFunctionGenerator(ODEFunctionGenerator):
         else:
             super(CythonODEFunctionGenerator, self).__init__(*args, **kwargs)
 
+    __init__.__doc__ = ODEFunctionGenerator.__init__.__doc__
+
     @staticmethod
     def _cythonize(outputs, inputs):
         return CythonMatrixGenerator(inputs, outputs).compile()
@@ -878,6 +880,8 @@ class TheanoODEFunctionGenerator(ODEFunctionGenerator):
             raise ImportError('Theano must be installed to use this class.')
         else:
             super(TheanoODEFunctionGenerator, self).__init__(*args, **kwargs)
+
+    __init__.__doc__ = ODEFunctionGenerator.__init__.__doc__
 
     def define_inputs(self):
 

--- a/pydy/codegen/tests/test_ode_function_generator.py
+++ b/pydy/codegen/tests/test_ode_function_generator.py
@@ -140,6 +140,12 @@ class TestODEFunctionGeneratorSubclasses(object):
 
         np.testing.assert_allclose(xdot, expected_xdot)
 
+    def test_init_doc(self):
+
+        for Subclass in self.ode_function_subclasses:
+            assert (Subclass.__init__.__doc__ ==
+                    ODEFunctionGenerator.__init__.__doc__)
+
     def test_generate_full_rhs(self):
 
         rhs = self.sys.eom_method.rhs()


### PR DESCRIPTION
Fixes issue #180.

Since __init__ was overridden in each of those generators, the nice long
docstring was lost. This adds it back in.

- [x] There are no merge conflicts.
- [x] If there is a related issue, a reference to that issue is in the
  commit message.
- [x] Unit tests have been added for the bug. (Please reference the issue #
  in the unit test.)
- [ ] The tests pass both locally (run `nosetests`) and on Travis CI.
- [x] The code follows PEP8 guidelines. (use a linter, e.g.
  [pylint](http://www.pylint.org), to check your code)
- [ ] The bug fix is documented in the [Release
  Notes](https://github.com/pydy/pydy#release-notes).
- [x] The code is backwards compatible. (All public methods/classes must
  follow deprecation cycles.)
- [x] All reviewer comments have been addressed.