### PR TITLE
Ensures that constants are ordered correctly in GUI.

### DIFF
--- a/pydy/viz/scene.py
+++ b/pydy/viz/scene.py
@@ -213,6 +213,8 @@ class Scene(object):
             self.generate_scene_dict(constant_map=constant_map)
 
         self._scene_data_dict["simulationData"] = self.simulation_json_file
+        # NOTE : Python 3 division is imported at the top of the file so
+        # this will be a float.
         self._scene_data_dict["timeDelta"] = 1 / fps
         self._scene_data_dict["timeSteps"] = dynamic_values.shape[0]
         self._scene_data_dict["constant_map"] = constant_map_for_json
@@ -235,8 +237,8 @@ class Scene(object):
         ==========
         constant_map : dictionary
             A map of symbolic constants to numerical values. This is
-            typically used if there are symbolics in the dimensions of the
-            shapes.
+            typically used if there are symbolics in the parameters of the
+            Shape objects.
 
         Returns
         =======
@@ -354,6 +356,9 @@ class Scene(object):
 
         """
         if not isinstance(system, System):
+            # NOTE : Not sure why the next line is here. Leaving it here in
+            # case it breaks something that is not tested.
+            self.system = None
             msg = "{} should be a valid pydy.System object".format(system)
             raise TypeError(msg)
         else:

--- a/pydy/viz/scene.py
+++ b/pydy/viz/scene.py
@@ -43,25 +43,23 @@ except ImportError:
 
 
 class Scene(object):
-    """
-    Scene class holds all the data required for the visualizations/
+    """The Scene class holds all the data required for the visualizations
     animation of a system.
 
     It has methods for inputting the numerical data from the numerical
-    integrations of Equations of Motions and convert them to JSON
-    values, which can be then parsed by Javascripts(webgls).
+    integrations of Equations of Motions and convert them to JSON values,
+    which can be then parsed by Javascripts(webgls).
 
     A scene object takes a ReferenceFrame, and a Point as required
-    arguments. The reference_frame and point act as the inertial
-    frame and origin with respect to which all objects are oriented
-    and rendered in the visualizations
+    arguments. The reference_frame and point act as the inertial frame and
+    origin with respect to which all objects are oriented and rendered in
+    the visualizations
 
-    A scene needs to be supplied with visualization_frames, Cameras,
-    and Light objects, as optional arguments.
-    A scene can also be supplied with the height and width of the
-    browser window where visualization would be displayed.
-    Default is 800 * 800.
+    A scene needs to be supplied with visualization_frames, Cameras, and
+    Light objects, as optional arguments.
 
+    A scene can also be supplied with the height and width of the browser
+    window where visualization would be displayed. Default is 800 * 800.
 
     """
     def __init__(self, reference_frame, origin, *visualization_frames,
@@ -92,15 +90,16 @@ class Scene(object):
             defined for this scene.
         """
 
-        self._reference_frame = reference_frame
-        self._origin = origin
-
+        self.reference_frame = reference_frame
+        self.origin = origin
         self.visualization_frames = list(visualization_frames)
 
         try:
-            self._name = kwargs['name']
+            self.name = kwargs['name']
         except KeyError:
-            self._name = 'unnamed'
+            self.name = 'unnamed'
+
+        # TODO : width and height are not even used!
 
         try:
             self._width = kwargs['width']
@@ -132,53 +131,41 @@ class Scene(object):
 
     @property
     def name(self):
-        """
-        Returns Name of Scene.
-        """
+        """Returns the name of the scene."""
         return self._name
 
     @name.setter
     def name(self, new_name):
-        """
-        sets name of scene.
-        """
+        """Sets the name of the scene."""
         if not isinstance(new_name, str):
-            raise TypeError('Name should be a valid str.')
+            raise TypeError("'name' should be a valid string.")
         else:
             self._name = new_name
 
     @property
     def origin(self):
-        """
-        returns Origin of the Scene.
-        """
+        """Returns the origin point of the scene."""
         return self._origin
 
     @origin.setter
     def origin(self, new_origin):
-        """
-        sets origin of the scene
-        """
+        """Sets the origin point of the scene."""
         if not isinstance(new_origin, Point):
-            raise TypeError('''origin should be a valid Point Object''')
+            raise TypeError("'origin' should be a valid Point object.")
         else:
             self._origin = new_origin
 
     @property
     def reference_frame(self):
-        """
-        returns reference_frame of the Scene.
-        """
+        """Returns the base reference frame of the scene."""
         return self._reference_frame
 
     @reference_frame.setter
     def reference_frame(self, new_reference_frame):
-        """
-        Sets reference frame for the scene.
-        """
+        """Sets the base reference frame for the scene."""
         if not isinstance(new_reference_frame, ReferenceFrame):
-            raise TypeError('''reference_frame should be a valid
-                                ReferenceFrame object.''')
+            raise TypeError("'reference_frame' should be a valid "
+                            "ReferenceFrame object.")
         else:
             self._reference_frame = new_reference_frame
 
@@ -186,109 +173,103 @@ class Scene(object):
                                     constant_variables, dynamic_values,
                                     constant_values, fps=30,
                                     outfile_prefix=None):
-        """
-        generate_visualization_json() method generates a json str, which is
-        saved to file.
+        """Creates two JSON files in the current working directory. One
+        contains the scene information and one contains the simulation data.
 
         Parameters
         ==========
-        dynamic_variables : Sympifyable list or tuple
-            This contains all the dynamic symbols or state variables
-            which are required for solving the transformation matrices
-            of all the frames of the scene.
-
-        constant_variables : Sympifyable list or tuple
-            This contains all the symbols for the parameters which are
-            used for defining various objects in the system.
-
-        dynamic_values : list or tuple
-            initial states of the system. The list or tuple
-            should be respective to the state_sym.
-
-        constant_values : list or tuple
-            values of the parameters. The list or tuple
-            should be respective to the par_sym.
-
-        fps : int
-            fps at which animation should be displayed.
-            Please not that this fps should not exceed
-            the hardware limit of the display device to
-            be used. Default is 30fps.
-
-        outfile_prefix : str
-            A prefix to be put while saving the scene_desc
-            and simulation_data files. Files will be named
-            as `outfile_prefix_scene_desc.json` and
-            `outfile_prefix_simulation_data.json`. If not specified
-            a timestamp shall be used as the prefix.
-
-        Returns
-        =======
-
-        The dictionary contains following keys:
-        1) Width of the scene.
-        2) Height of the scene.
-        3) name of the scene.
-        4) frames in the scene, which contains sub-dictionaries
-           of all the visualization frames information.
+        dynamic_variables : sequence of SymPy functions of time, len(m)
+            The variables representing the state of the system. They should
+            be in the same order as ``dynamic_values``.
+        constant_variables : sequence of SymPy symbols, len(p)
+            The variables representing the constants in the system. They
+            should be in the same order as ``constant_variables``.
+        dynamic_values : ndarray, shape(n, m)
+            The trajectories of the states.
+        constant_values : ndarray, shape(p,)
+            The numerical values of the constants.
+        fps : int, optional, default=30
+            Frames per second at which animation should be displayed. Please
+            not that this should not exceed the hardware limit of the
+            display device to be used. Default is 30fps.
+        outfile_prefix : str, optional, default=None
+            A prefix for the JSON files. The files will be named as
+            `outfile_prefix_scene_desc.json` and
+            `outfile_prefix_simulation_data.json`. If not specified a
+            timestamp shall be used as the prefix.
 
 
         """
 
+        # TODO : The colons need to be removed from this file name.
         if outfile_prefix is None:
-            outfile_prefix = "_".join(str(datetime.datetime.now()).\
-                                  split(".")[0].split(" "))
+            timestamp = str(datetime.datetime.now())
+            outfile_prefix = "_".join(timestamp.split(".")[0].split(" "))
 
-        #Saving the arguments for re-running simulations
+        self.scene_json_file = outfile_prefix + "_scene_desc.json"
+        self.simulation_json_file = outfile_prefix + "_simulation_data.json"
+
         self.constant_variables = constant_variables
         self.dynamic_variables = dynamic_variables
         self.constant_values = constant_values
         self.dynamic_values = dynamic_values
         self.outfile_prefix = outfile_prefix
         self.fps = fps
+
         constant_map = dict(zip(constant_variables, constant_values))
+        # TODO : This assumes that all constants have unique strings an that
+        # they are valid strings in JSON.
         constant_variables_str = [str(i) for i in constant_variables]
-        constant_map_for_json = dict(zip(constant_variables_str, constant_values))
-        self.scene_json_file = outfile_prefix + "_scene_desc.json"
-        self.simulation_json_file = outfile_prefix + "_simulation_data.json"
+        constant_map_for_json = dict(zip(constant_variables_str,
+                                         constant_values))
 
-        self._simulation_data_dict = self.generate_simulation_dict(dynamic_variables,
-                                                           constant_variables,
-                                                           dynamic_values,
-                                                           constant_values)
-        self._scene_data_dict = self.generate_scene_dict(constant_map=constant_map)
+        self._simulation_data_dict = \
+            self.generate_simulation_dict(dynamic_variables,
+                                          constant_variables,
+                                          dynamic_values, constant_values)
+
+        self._scene_data_dict = \
+            self.generate_scene_dict(constant_map=constant_map)
+
         self._scene_data_dict["simulationData"] = self.simulation_json_file
-
-        self._scene_data_dict["timeDelta"] = 1/fps
-        self._scene_data_dict["timeSteps"] = len(dynamic_values)
-
-
+        self._scene_data_dict["timeDelta"] = 1 / fps
+        self._scene_data_dict["timeSteps"] = dynamic_values.shape[0]
         self._scene_data_dict["constant_map"] = constant_map_for_json
-        scene_data_outfile = open(self.scene_json_file, 'w')
-        scene_data_outfile.write(json.dumps(self._scene_data_dict, indent=4,
-                                 separators=(',', ': ')))
-        scene_data_outfile.close()
 
-        simulation_data_outfile = open(self.simulation_json_file, 'w')
-        simulation_data_outfile.write(json.dumps(self._simulation_data_dict, indent=4,
-                                 separators=(',', ': ')))
-        simulation_data_outfile.close()
+        with open(self.scene_json_file, 'w') as scene_data_outfile:
+            scene_data_outfile.write(json.dumps(self._scene_data_dict,
+                                                indent=4,
+                                                separators=(',', ': ')))
+
+        with open(self.simulation_json_file, 'w') as simulation_data_outfile:
+            simulation_data_outfile.write(json.dumps(
+                self._simulation_data_dict, indent=4,
+                separators=(',', ': ')))
 
     def generate_scene_dict(self, constant_map={}):
-        """
-        This method is used to create the dictionary compatible with
-        PyDy visualizer. This JSON file contains all the relevant information
-        required by PyDy visualizer to draw the scene on the canvas.
+        """Generates a dictionary containing all of the information needed
+        to build the scene.
 
+        Parameters
+        ==========
+        constant_map : dictionary
+            A map of symbolic constants to numerical values. This is
+            typically used if there are symbolics in the dimensions of the
+            shapes.
+
+        Returns
+        =======
+        scene_info : dictionary
 
         """
 
         self._scene_info = {}
         self._scene_info["source"] = "PyDy"
-        self._scene_info["name"] = self._name
-        self._scene_info["newtonian_frame"] = str(self._reference_frame)
-        self._scene_info["workspaceSize"] = 0.2#This should be accomodated in scene
-                                                #instead of width/height of scene
+        self._scene_info["name"] = self.name
+        self._scene_info["newtonian_frame"] = str(self.reference_frame)
+        # TODO : This should be accomodated in scene instead of width/height
+        # of scene.
+        self._scene_info["workspaceSize"] = 0.2
 
         self._scene_info["objects"] = {}
         self._scene_info["cameras"] = {}
@@ -297,7 +278,6 @@ class Scene(object):
         for frame in self.visualization_frames:
             _object_info = frame.generate_scene_dict(constant_map=constant_map)
             self._scene_info["objects"].update(_object_info)
-
 
         for camera in self.cameras:
             _object_info = camera.generate_scene_dict()
@@ -310,72 +290,98 @@ class Scene(object):
         return self._scene_info
 
     def generate_simulation_dict(self, dynamic_variables,
-                                    constant_variables, dynamic_values,
-                                    constant_values):
-        """
-        This method is used to create the JSON file compatible with
-        PyDy visualizer. This JSON file consists of all the simulation data
-        along with references to the objects, for allowing motion to the
-        objects in the PyDy visualizer.
+                                 constant_variables, dynamic_values,
+                                 constant_values):
+        """Returns a dictionary containing all of the simulation
+        information. It consists of all the simulation data along with
+        references to the objects, for allowing motion to the objects in the
+        PyDy visualizer.
+
+        Parameters
+        ==========
+        dynamic_variables : sequence of SymPy functions of time, len(m)
+            The variables representing the state of the system. They should
+            be in the same order as ``dynamic_values``.
+        constant_variables : sequence of SymPy symbols, len(p)
+            The variables representing the constants in the system. They
+            should be in the same order as ``constant_variables``.
+        dynamic_values : ndarray, shape(n, m)
+            The trajectories of the states.
+        constant_values : ndarray, shape(p,)
+            The numerical values of the constants.
+
+        Returns
+        =======
+        simulation_info : dictionary
+
+        Notes
+        =====
+
+        This method must be called before ``generate_scene_dict``.
 
         """
         self._simulation_info = {}
 
         for frame in self.visualization_frames:
-            frame.generate_transformation_matrix(self._reference_frame,
-                                                 self._origin)
+            frame.generate_transformation_matrix(self.reference_frame,
+                                                 self.origin)
             frame.generate_numeric_transform_function(dynamic_variables,
                                                       constant_variables)
             frame.evaluate_transformation_matrix(dynamic_values,
-                                                         constant_values)
-
+                                                 constant_values)
 
             self._simulation_info.update(frame.generate_simulation_dict())
 
         for camera in self.cameras:
-            camera.generate_transformation_matrix(self._reference_frame,
-                                                 self._origin)
+            camera.generate_transformation_matrix(self.reference_frame,
+                                                  self.origin)
             camera.generate_numeric_transform_function(dynamic_variables,
-                                                      constant_variables)
+                                                       constant_variables)
             camera.evaluate_transformation_matrix(dynamic_values,
-                                                         constant_values)
+                                                  constant_values)
 
             self._simulation_info.update(camera.generate_simulation_dict())
 
         for light in self.lights:
-            light.generate_transformation_matrix(self._reference_frame,
-                                                 self._origin)
+            light.generate_transformation_matrix(self.reference_frame,
+                                                 self.origin)
             light.generate_numeric_transform_function(dynamic_variables,
                                                       constant_variables)
             light.evaluate_transformation_matrix(dynamic_values,
-                                                         constant_values)
+                                                 constant_values)
 
             self._simulation_info.update(light.generate_simulation_dict())
 
+        # TODO : This is bad practice. The method should either return the
+        # data or mutate the object, but not both.
         return self._simulation_info
 
     def generate_visualization_json_system(self, system, **kwargs):
-        """ Alternative method compatible with System class
-        for generating visualization JSON.
+        """Creates the visualization JSON files for the provided system.
 
         Parameters
-        ----------
-        system : object, pydy.System
+        ==========
+        system : pydy.system.System
+            A fully developed PyDy system that is prepared for the
+            ``.integrate()`` method.
 
-        Keyword arguments are same as generate_visualization_json.
+        Notes
+        =====
+
+        The optional keyword arguments are same as the
+        ``generate_visualization_json`` method.
 
         """
         if not isinstance(system, System):
-            self.system = None
-            raise TypeError("{} should be a valid pydy.System object".format(system))
+            msg = "{} should be a valid pydy.System object".format(system)
+            raise TypeError(msg)
         else:
-            #save system
             self.system = system
 
         self.generate_visualization_json(system.states,
-                                          system.constants_symbols,
-                                          system.integrate(),
-                                          system.constants.values(), **kwargs)
+                                         system.constants.keys(),
+                                         system.integrate(),
+                                         system.constants.values(), **kwargs)
 
     def create_static_html(self, overwrite=False, silent=False):
 
@@ -520,14 +526,18 @@ class Scene(object):
             self.button = widgets.Button(description="Rerun Simulations")
 
         def button_click(clicked):
+
             if ipython_less_than_3:
                 self.button.add_class('disabled')
             else:
                 self.button._dom_classes = ['disabled']
+
             self.button.description = 'Rerunning Simulation ...'
             self.constant_values = []
+
             for i in self._widget_dict.values():
                 self.constant_values.append(i.value)
+
             if self.system is not None:
                 # update system constants
                 self.system.constants = dict(zip(self.system.constants,
@@ -540,11 +550,13 @@ class Scene(object):
                     self.constant_values,
                     fps=self.fps,
                     outfile_prefix=self.outfile_prefix)
+
             self.create_static_html(overwrite=True, silent=True)
             js = 'jQuery("#json-input").val("{}");'.format('static/' +
                                                            self.scene_json_file)
             display(Javascript(js))
             display(Javascript('jQuery("#simulation-load").click()'))
+
             if ipython_less_than_3:
                 self.button.remove_class('disabled')
             else:
@@ -554,6 +566,7 @@ class Scene(object):
 
         self.button.on_click(button_click)
         html_file = open("static/index_ipython.html")
+
         if ipython_less_than_3:
             self.html_widget = widgets.HTMLWidget(
                 value=html_file.read().format(load_url='static/' +
@@ -578,6 +591,7 @@ class Scene(object):
         display(self.container)
         display(self.button)
         display(self.html_widget)
+
         if ipython_less_than_3:
             self.button.add_class('btn-info')
         else:

--- a/pydy/viz/scene.py
+++ b/pydy/viz/scene.py
@@ -95,8 +95,8 @@ class Scene(object):
             self.cameras = kwargs['cameras']
         except KeyError:
             self.cameras = [PerspectiveCamera('DefaultCamera',
-                            self._reference_frame,
-                            self._origin.locatenew(
+                            self.reference_frame,
+                            self.origin.locatenew(
                                 'p_camera',
                                 10*self._reference_frame.z))]
 
@@ -104,8 +104,8 @@ class Scene(object):
             self.lights = kwargs['lights']
         except KeyError:
             self.lights = [PointLight('DefaultLight',
-                           self._reference_frame,
-                           self._origin.locatenew(
+                           self.reference_frame,
+                           self.origin.locatenew(
                                'p_light',
                                10*self._reference_frame.z))]
 
@@ -197,8 +197,8 @@ class Scene(object):
         self.fps = fps
 
         constant_map = dict(zip(constant_variables, constant_values))
-        # TODO : This assumes that all constants have unique strings an that
-        # they are valid strings in JSON.
+        # TODO : This assumes that all constants have unique strings and
+        # that they are valid strings for the JSON file.
         constant_variables_str = [str(i) for i in constant_variables]
         constant_map_for_json = dict(zip(constant_variables_str,
                                          constant_values))
@@ -206,7 +206,8 @@ class Scene(object):
         self._simulation_data_dict = \
             self.generate_simulation_dict(dynamic_variables,
                                           constant_variables,
-                                          dynamic_values, constant_values)
+                                          dynamic_values,
+                                          constant_values)
 
         self._scene_data_dict = \
             self.generate_scene_dict(constant_map=constant_map)

--- a/pydy/viz/scene.py
+++ b/pydy/viz/scene.py
@@ -58,9 +58,6 @@ class Scene(object):
     A scene needs to be supplied with visualization_frames, Cameras, and
     Light objects, as optional arguments.
 
-    A scene can also be supplied with the height and width of the browser
-    window where visualization would be displayed. Default is 800 * 800.
-
     """
     def __init__(self, reference_frame, origin, *visualization_frames,
                  **kwargs):
@@ -79,11 +76,6 @@ class Scene(object):
             the scene.
         name : str, optional
             Name of Scene object.
-        width : int or float, optional
-            The width of the canvas used for visualizations. Default is
-            800px.
-        height : int or float, optional
-            Height of the canvas used for visualizations. Default is 800px.
         camera : Camera, optional
             The camera with which to display the object. Default is
             PerspectiveCamera, with reference_frame and origin same as
@@ -98,18 +90,6 @@ class Scene(object):
             self.name = kwargs['name']
         except KeyError:
             self.name = 'unnamed'
-
-        # TODO : width and height are not even used!
-
-        try:
-            self._width = kwargs['width']
-        except KeyError:
-            self._width = 800
-
-        try:
-            self._height = kwargs['height']
-        except KeyError:
-            self._height = 800
 
         try:
             self.cameras = kwargs['cameras']

--- a/pydy/viz/tests/test_scene.py
+++ b/pydy/viz/tests/test_scene.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 
 import os
+import shutil
 
 from numpy import linspace
 from sympy import symbols
@@ -9,50 +10,213 @@ import sympy.physics.mechanics as me
 from ...system import System
 from ..shapes import Sphere
 from ..visualization_frame import VisualizationFrame
+from ..camera import PerspectiveCamera
+from ..light import PointLight
 from ..scene import Scene
 
 
-def test_create_static_html():
-    # derive simple system
-    mass, stiffness, damping, gravity = symbols('m, k, c, g')
-    position, speed = me.dynamicsymbols('x v')
-    positiond = me.dynamicsymbols('x', 1)
-    ceiling = me.ReferenceFrame('N')
-    origin = me.Point('origin')
-    origin.set_vel(ceiling, 0)
-    center = origin.locatenew('center', position * ceiling.x)
-    center.set_vel(ceiling, speed * ceiling.x)
-    block = me.Particle('block', center, mass)
-    kinematic_equations = [speed - positiond]
-    total_force = mass * gravity - stiffness * position - damping * speed
-    forces = [(center, total_force * ceiling.x)]
-    particles = [block]
-    kane = me.KanesMethod(ceiling, q_ind=[position], u_ind=[speed],
-                          kd_eqs=kinematic_equations)
-    kane.kanes_equations(forces, particles)
-    sys = System(kane,
-                 initial_conditions={position: 0.1, speed: -1.0},
-                 constants={mass: 1.0, stiffness: 1.0, damping: 0.2,
-                            gravity: 9.8})
+class TestScene(object):
 
-    # integrate eoms
-    t = linspace(0.0, 10.0, 100)
-    sys.times = t
-    y = sys.integrate()
+    def setup(self):
 
-    # create visualization
-    sphere = Sphere()
-    viz_frame = VisualizationFrame(ceiling, block, sphere)
-    scene = Scene(ceiling, origin, viz_frame)
-    scene.generate_visualization_json_system(sys, outfile_prefix="test")
+        mass, stiffness, damping, gravity = symbols('m, k, c, g')
 
-    # test static dir creation
-    scene.create_static_html(overwrite=True)
-    assert os.path.exists('static')
-    assert os.path.exists('static/index.html')
-    assert os.path.exists('static/test_scene_desc.json')
-    assert os.path.exists('static/test_simulation_data.json')
+        position, speed = me.dynamicsymbols('x v')
+        positiond = me.dynamicsymbols('x', 1)
 
-    # test static dir deletion
-    scene.remove_static_html(force=True)
-    assert not os.path.exists('static')
+        kinematic_equations = [speed - positiond]
+
+        ceiling = me.ReferenceFrame('N')
+
+        origin = me.Point('origin')
+        origin.set_vel(ceiling, 0)
+        center = origin.locatenew('center', position * ceiling.x)
+        center.set_vel(ceiling, speed * ceiling.x)
+
+        block = me.Particle('block', center, mass)
+        particles = [block]
+
+        total_force = mass * gravity - stiffness * position - damping * speed
+        forces = [(center, total_force * ceiling.x)]
+
+        kane = me.KanesMethod(ceiling, q_ind=[position], u_ind=[speed],
+                              kd_eqs=kinematic_equations)
+        kane.kanes_equations(forces, particles)
+
+        self.sys = System(kane)
+        self.sys.initial_conditions = {position: 0.1, speed: -1.0}
+        self.constants = {mass: 1.0, stiffness: 1.0, damping: 0.2,
+                          gravity: 9.8}
+        self.sys.times = linspace(0.0, 0.01, 2)
+
+        sphere = Sphere()
+
+        self.ref_frame = ceiling
+        self.origin = origin
+        self.viz_frame = VisualizationFrame(ceiling, block, sphere)
+
+    def test_init(self):
+
+        # test minimal args
+        scene = Scene(self.ref_frame, self.origin)
+
+        assert scene.reference_frame == self.ref_frame
+        assert scene.origin == self.origin
+        assert scene.name == 'unnamed'
+        assert scene._width == 800
+        assert scene._height == 800
+        # TODO : These are failing.
+        #assert scene.cameras == [PerspectiveCamera('DefaultCamera',
+                                                   #self.ref_frame,
+                                                   #self.origin.locatenew(
+                                                       #'p_camera', 10 *
+                                                       #self.ref_frame.z))]
+        #assert scene.lights == [PointLight('DefaultLight', self.ref_frame,
+                                           #self.origin.locatenew(
+                                               #'p_light', 10 *
+                                               #self.ref_frame.z))]
+
+        scene.visualization_frames = [self.viz_frame]
+        assert scene.visualization_frames == [self.viz_frame]
+
+        # test maximal args/kwargs
+        custom_camera = PerspectiveCamera('my_camera', self.ref_frame,
+                                          self.origin.locatenew(
+                                              'cam_point', 20 *
+                                              self.ref_frame.z))
+
+        custom_light = PointLight('my_light', self.ref_frame,
+                                  self.origin.locatenew('light_point', 20 *
+                                                        self.ref_frame.y))
+
+        scene = Scene(self.ref_frame, self.origin, self.viz_frame,
+                      name='my_scene', width=200, height=300,
+                      cameras=[custom_camera], lights=[custom_light])
+
+        assert scene.visualization_frames == [self.viz_frame]
+        assert scene.name == 'my_scene'
+        assert scene._width == 200
+        assert scene._height == 300
+        assert scene.cameras == [custom_camera]
+        assert scene.lights == [custom_light]
+
+    def test_generate_simulation_dict(self):
+
+        scene = Scene(self.ref_frame, self.origin, self.viz_frame)
+
+        light_id = id(scene.lights[0])
+        camera_id = id(scene.cameras[0])
+        viz_frame_id = id(scene.visualization_frames[0])
+
+        sim_dict = scene.generate_simulation_dict(self.sys.states,
+                                                  self.sys.constants.keys(),
+                                                  self.sys.integrate(),
+                                                  self.sys.constants.values())
+
+        expected_dict = {viz_frame_id: [[1.0, 0.0, 0.0, 0.0,
+                                         0.0, 1.0, 0.0, 0.0,
+                                         0.0, 0.0, 1.0, 0.0,
+                                         0.1, 0.0, 0.0, 1.0],
+                                        [1.0, 0.0, 0.0, 0.0,
+                                         0.0, 1.0, 0.0, 0.0,
+                                         0.0, 0.0, 1.0, 0.0,
+                                         0.09009483961898038, 0.0, 0.0, 1.0]],
+                         light_id: [[1.0, 0.0, 0.0, 0.0,
+                                     0.0, 1.0, 0.0, 0.0,
+                                     0.0, 0.0, 1.0, 0.0,
+                                     0.0, 0.0, 10.0, 1.0],
+                                    [1.0, 0.0, 0.0, 0.0,
+                                     0.0, 1.0, 0.0, 0.0,
+                                     0.0, 0.0, 1.0, 0.0,
+                                     0.0, 0.0, 10.0, 1.0]],
+                         camera_id: [[1.0, 0.0, 0.0, 0.0,
+                                      0.0, 1.0, 0.0, 0.0,
+                                      0.0, 0.0, 1.0, 0.0,
+                                      0.0, 0.0, 10.0, 1.0],
+                                     [1.0, 0.0, 0.0, 0.0,
+                                      0.0, 1.0, 0.0, 0.0,
+                                      0.0, 0.0, 1.0, 0.0,
+                                      0.0, 0.0, 10.0, 1.0]]}
+
+        # TODO : This needs floating point comparisons and I think the hash
+        # value changes everytime the method is called.
+        assert sim_dict == expected_dict
+
+    def test_generate_scene_dict(self):
+
+        scene = Scene(self.ref_frame, self.origin, self.viz_frame)
+
+        light_id = id(scene.lights[0])
+        camera_id = id(scene.cameras[0])
+        viz_frame_id = id(scene.visualization_frames[0])
+
+        # NOTE : generate_simulation_dict must be called before
+        # generate_scene_dict
+        sim_dict = scene.generate_simulation_dict(self.sys.states,
+                                                  self.sys.constants.keys(),
+                                                  self.sys.integrate(),
+                                                  self.sys.constants.values())
+        scene_dict = scene.generate_scene_dict()
+
+        expected_scene_dict = \
+            {'newtonian_frame': 'N',
+             'name': 'unnamed',
+             'workspaceSize': 0.2,
+             'source': 'PyDy',
+             'lights': {light_id: {'color': 'white',
+                                   'init_orientation':
+                                       [1.0, 0.0, 0.0, 0.0,
+                                        0.0, 1.0, 0.0, 0.0,
+                                        0.0, 0.0, 1.0, 0.0,
+                                        0.0, 0.0, 10.0, 1.0],
+                                    'simulation_id': light_id,
+                                    'type': 'PointLight',
+                                    'name': 'DefaultLight'}},
+             'cameras': {camera_id: {'fov': 45.0,
+                                     'name': 'DefaultCamera',
+                                     'far': 1000.0,
+                                     'simulation_id': camera_id,
+                                     'near': 1.0,
+                                     'init_orientation':
+                                         [1.0, 0.0, 0.0, 0.0,
+                                          0.0, 1.0, 0.0, 0.0,
+                                          0.0, 0.0, 1.0, 0.0,
+                                          0.0, 0.0, 10.0, 1.0],
+                                           'type': 'PerspectiveCamera'}},
+             'objects': {viz_frame_id: {'simulation_id': viz_frame_id,
+                                        'name': 'unnamed',
+                                        'color': 'grey',
+                                        'material': 'default',
+                                        'reference_frame_name': 'N',
+                                        'radius': 10.0,
+                                        'init_orientation':
+                                            [1.0, 0.0, 0.0, 0.0,
+                                             0.0, 1.0, 0.0, 0.0,
+                                             0.0, 0.0, 1.0, 0.0,
+                                             0.1, 0.0, 0.0, 1.0],
+                                        'type': 'Sphere'}}}
+
+        assert scene_dict == expected_scene_dict
+
+        # TODO : Test the constant_map kwarg.
+
+    def test_create_static_html(self):
+
+        scene = Scene(self.ref_frame, self.origin, self.viz_frame)
+        scene.generate_visualization_json_system(self.sys,
+                                                 outfile_prefix="test")
+
+        # test static dir creation
+        scene.create_static_html(overwrite=True)
+        assert os.path.exists('static')
+        assert os.path.exists('static/index.html')
+        assert os.path.exists('static/test_scene_desc.json')
+        assert os.path.exists('static/test_simulation_data.json')
+
+        # test static dir deletion
+        scene.remove_static_html(force=True)
+        assert not os.path.exists('static')
+
+    def cleanup(self):
+
+        shutil.rmtree('static')

--- a/pydy/viz/tests/test_scene.py
+++ b/pydy/viz/tests/test_scene.py
@@ -63,8 +63,6 @@ class TestScene(object):
         assert scene.reference_frame == self.ref_frame
         assert scene.origin == self.origin
         assert scene.name == 'unnamed'
-        assert scene._width == 800
-        assert scene._height == 800
         # TODO : These are failing.
         #assert scene.cameras == [PerspectiveCamera('DefaultCamera',
                                                    #self.ref_frame,
@@ -90,13 +88,11 @@ class TestScene(object):
                                                         self.ref_frame.y))
 
         scene = Scene(self.ref_frame, self.origin, self.viz_frame,
-                      name='my_scene', width=200, height=300,
-                      cameras=[custom_camera], lights=[custom_light])
+                      name='my_scene', cameras=[custom_camera],
+                      lights=[custom_light])
 
         assert scene.visualization_frames == [self.viz_frame]
         assert scene.name == 'my_scene'
-        assert scene._width == 200
-        assert scene._height == 300
         assert scene.cameras == [custom_camera]
         assert scene.lights == [custom_light]
 

--- a/pydy/viz/tests/test_scene.py
+++ b/pydy/viz/tests/test_scene.py
@@ -46,7 +46,7 @@ class TestScene(object):
 
         self.sys = System(kane)
         self.sys.initial_conditions = {position: 0.1, speed: -1.0}
-        self.sys.constants = {mass: 1.0, stiffness: 1.0, damping: 0.2,
+        self.sys.constants = {mass: 1.0, stiffness: 2.0, damping: 3.0,
                               gravity: 9.8}
         self.sys.times = linspace(0.0, 0.01, 2)
 
@@ -115,7 +115,7 @@ class TestScene(object):
                                         [1.0, 0.0, 0.0, 0.0,
                                          0.0, 1.0, 0.0, 0.0,
                                          0.0, 0.0, 1.0, 0.0,
-                                         0.09049483063184803, 0.0, 0.0, 1.0]],
+                                         0.09062405469543587, 0.0, 0.0, 1.0]],
                          light_id: [[1.0, 0.0, 0.0, 0.0,
                                      0.0, 1.0, 0.0, 0.0,
                                      0.0, 0.0, 1.0, 0.0,
@@ -225,8 +225,8 @@ class TestScene(object):
         scene.generate_visualization_json_system(self.sys)
 
         # Tests issue #204
-        assert scene._scene_data_dict['constant_map'] == {'m': 1.0, 'k': 1.0,
-                                                          'c': 0.2, 'g': 9.8}
+        assert scene._scene_data_dict['constant_map'] == {'m': 1.0, 'k': 2.0,
+                                                          'c': 3.0, 'g': 9.8}
 
     def teardown(self):
 

--- a/pydy/viz/tests/test_scene.py
+++ b/pydy/viz/tests/test_scene.py
@@ -5,6 +5,7 @@ import shutil
 import glob
 
 from numpy import linspace
+from numpy.testing import assert_allclose
 from sympy import symbols
 import sympy.physics.mechanics as me
 
@@ -133,7 +134,10 @@ class TestScene(object):
                                       0.0, 0.0, 1.0, 0.0,
                                       0.0, 0.0, 10.0, 1.0]]}
 
-        assert sim_dict == expected_dict
+        assert sorted(expected_dict.keys()) == sorted(sim_dict.keys())
+
+        for k, v in sim_dict.items():
+            assert_allclose(v, expected_dict[k])
 
     def test_generate_scene_dict(self):
 

--- a/pydy/viz/tests/test_scene.py
+++ b/pydy/viz/tests/test_scene.py
@@ -20,6 +20,7 @@ from ..scene import Scene
 class TestScene(object):
 
     def setup(self):
+        """Setups a simple 1 DoF mass spring damper system visualization."""
 
         mass, stiffness, damping, gravity = symbols('m, k, c, g')
 


### PR DESCRIPTION
Fixes #204

I've tested this on the mass_spring_damper example and it works correctly now. There is also a ton of code clean up and new tests for Scene. I also removed the width and height attributes from Scene as they were not used anywhere.

- [x] There are no merge conflicts.
- [x] If there is a related issue, a reference to that issue is in the
  commit message.
- [x] Unit tests have been added for the bug. (Please reference the issue #
  in the unit test.)
- [x] The tests pass both locally (run `nosetests`) and on Travis CI.
- [x] The code follows PEP8 guidelines. (use a linter, e.g.
  [pylint](http://www.pylint.org), to check your code)
- [x] The bug fix is documented in the [Release
  Notes](https://github.com/pydy/pydy#release-notes).
- [x] The code is backwards compatible. (All public methods/classes must
  follow deprecation cycles.)
- [x] All reviewer comments have been addressed.