### PR TITLE
Adds a test for the OrthoGraphicCamera dict generation.

### DIFF
--- a/pydy/viz/camera.py
+++ b/pydy/viz/camera.py
@@ -367,13 +367,13 @@ class OrthoGraphicCamera(VisualizationFrame):
               4. init_orientation: Initial orientation of the camera
 
         """
-        scene_dict = {}
-        scene_dict['name'] = self.name
-        scene_dict['type'] = self.__repr__()
-        scene_dict['near'] = self.near
-        scene_dict['far'] = self.far
-        scene_dict["simulation_id"] = id(self)
-        scene_dict["init_orientation"] = self._visualization_matrix[0]
+        scene_dict = {id(self): {}}
+        scene_dict[id(self)]['name'] = self.name
+        scene_dict[id(self)]['type'] = self.__repr__()
+        scene_dict[id(self)]['near'] = self.near
+        scene_dict[id(self)]['far'] = self.far
+        scene_dict[id(self)]["simulation_id"] = id(self)
+        scene_dict[id(self)]["init_orientation"] = self._visualization_matrix[0]
 
         return scene_dict
 


### PR DESCRIPTION
This was a test for issue #207, but it ended up uncovering a bug in the
OrthoGraphicCamera. PR #210 needs to be merged before this one.

- [x] There are no merge conflicts.
- [x] If there is a related issue, a reference to that issue is in the
  commit message.
- [x] Unit tests have been added for the bug. (Please reference the issue #
  in the unit test.)
- [x] The tests pass both locally (run `nosetests`) and on Travis CI.
- [x] The code follows PEP8 guidelines. (use a linter, e.g.
  [pylint](http://www.pylint.org), to check your code)
- [x] The bug fix is documented in the [Release
  Notes](https://github.com/pydy/pydy#release-notes).
- [x] The code is backwards compatible. (All public methods/classes must
  follow deprecation cycles.)
- [x] All reviewer comments have been addressed.