### PR TITLE
Fix bug 215

### DIFF
--- a/examples/rattleback/cpp/CMakeLists.txt
+++ b/examples/rattleback/cpp/CMakeLists.txt
@@ -41,8 +41,9 @@ target_link_libraries(paraboloid_sim
                       ${GSL_LIBRARIES})
 
 add_executable(ellipsoid_equilibrium ellipsoid_eq.cc)
-target_link_libraries(ellipsoid_equilibrium rattleback vtkRendering)
+target_link_libraries(ellipsoid_equilibrium rattleback ${VTK_LIBRARIES})
 
-add_executable(RattleBackAnimation RattleBackAnimation.cc
-                                   RattleBackCallback.cc)
-target_link_libraries(RattleBackAnimation rattleback vtkRendering)
+# rattleback animation source files are missing:
+#add_executable(RattleBackAnimation RattleBackAnimation.cc
+#                                   RattleBackCallback.cc)
+#target_link_libraries(RattleBackAnimation rattleback ${VTK_LIBRARIES})

--- a/examples/rattleback/ellipsoid_no_slip_steady.py
+++ b/examples/rattleback/ellipsoid_no_slip_steady.py
@@ -22,11 +22,10 @@ Y = N.orientnew('Y', 'Axis', [q[0], N.z]) # Yaw Frame
 L = Y.orientnew('L', 'Axis', [q[1], Y.x]) # Lean Frame
 R = L.orientnew('R', 'Axis', [q[2], L.y]) # Rattleback body fixed frame
 
-print R.dcm(Y)
+print(R.dcm(Y))
 
 I = inertia(R, Ixx, Iyy, Izz, Ixy, Iyz, Ixz)    # Inertia dyadic
-print I.express(Y)
-stop
+print(I.express(Y))
 # Rattleback ground contact point
 P = Point('P')
 
@@ -35,8 +34,8 @@ P = Point('P')
 # David A. Levinson, 1982, International Journal of Non-Linear Mechanics
 #mu = [dot(rk, Y.z) for rk in R]
 #eps = sqrt((a*mu[0])**2 + (b*mu[1])**2 + (c*mu[2])**2)
-O = P.locatenew('RO', -rx*R.x - rx*R.y - rx*R.z)
-RO = O.locatenew('O', d*R.x + e*R.y + f*R.z)
+O = P.locatenew('O', -rx*R.x - rx*R.y - rx*R.z)
+RO = O.locatenew('RO', d*R.x + e*R.y + f*R.z)
 
 w_r_n = wx*R.x + wy*R.y + wz*R.z
 omega_dict = {wx: dot(qd[0]*Y.z, R.x),
@@ -52,18 +51,19 @@ mu_dict = {mu_x: dot(R.x, Y.z), mu_y: dot(R.y, Y.z), mu_z: dot(R.z, Y.z)}
 F_RO = Fx*R.x + Fy*R.y + Fz*R.z + m*g*(mu_x*R.x + mu_y*R.y + mu_z*R.z)
 newton_eqn = F_RO - m*a_ro_n
 force_scalars = solve([dot(newton_eqn, uv).expand() for uv in R], [Fx, Fy, Fz])
-#print "v_ro_n =", v_ro_n
-#print "a_ro_n =", a_ro_n
-#print "Force scalars =", force_scalars
+#print("v_ro_n =", v_ro_n)
+#print("a_ro_n =", a_ro_n)
+#print("Force scalars =", force_scalars)
 euler_eqn = cross(P.pos_from(RO), F_RO) - cross(w_r_n, dot(I, w_r_n))
-#print euler_eqn
+#print(euler_eqn)
 
-print dot(euler_eqn, R.x).subs(omega_dict).expand()
-print dot(euler_eqn, R.y).subs(omega_dict).expand()
-print dot(euler_eqn, R.z).subs(omega_dict).expand().subs(force_scalars).expand().subs(mu_dict).expand()
-stop
+print(dot(euler_eqn, R.x).subs(omega_dict).expand())
+print(dot(euler_eqn, R.y).subs(omega_dict).expand())
+print(dot(euler_eqn, R.z).subs(omega_dict).expand().subs(force_scalars).expand().subs(mu_dict).expand())
 # Mass center position and velocity
 RO = O.locatenew('RO', d*R.x + e*R.y + f*R.z)
+RO.set_vel(N, v_ro_n)
+O.v2pt_theory(RO, N, R)
 
 # Partial angular velocities and partial velocities
 partial_w = [R.ang_vel_in(N).diff(qdi, N) for qdi in qd]
@@ -124,8 +124,7 @@ for i in range(4):
     dh[2*i + j] = h[i].diff(q[j+1])
 
 # Subsitution dictionary to replace dynamic symbols with regular symbols
-symbol_dict = {q[1]: Symbol('q1'), q[2]: Symbol('q2'), qd[0]: Symbol('qd0'),
-               r[0]: Symbol('rx'), r[1]: Symbol('ry'),  r[2]: Symbol('rz')}
+symbol_dict = {q[1]: Symbol('q1'), q[2]: Symbol('q2'), qd[0]: Symbol('qd0')}
 
 for i in range(4):
   h[i] = h[i].subs(symbol_dict)
@@ -161,6 +160,5 @@ for i in range(8):
 import re
 output_code = re.sub(r"z(\d+)", r"z[\1]", output_code)
 
-f = file("ellipsoid_no_slip_steady.txt", 'w')
-f.write(output_code)
-f.close()
+with open ("ellipsoid_no_slip_steady.txt", 'w') as f:
+    f.write(output_code)

--- a/examples/rattleback/paraboloid_no_slip.py
+++ b/examples/rattleback/paraboloid_no_slip.py
@@ -75,7 +75,7 @@ R.set_ang_acc(N, ud[0]*R.x + ud[1]*R.y + ud[2]*R.z)
 RO.set_acc(N, RO.vel(N).diff(t, R) + cross(R.ang_vel_in(N), RO.vel(N)))
 
 # Forces and Torques
-F_P = sum([cf*uv for cf, uv in zip(CF, Y)])
+F_P = sum([cf*uv for cf, uv in zip(CF, Y)], Vector(0))
 F_RO = m*g*Y.z
 T_R = -s*R.ang_vel_in(N)
 
@@ -91,8 +91,8 @@ T_star = - dot(R.ang_acc_in(N), I)\
          - cross(R.ang_vel_in(N), dot(I, R.ang_vel_in(N)))
 
 # Isolate the parts that involve only time derivatives of u's
-R_star_udot = sum([R_star.diff(udi, N)*udi for udi in ud])
-T_star_udot = sum([T_star.diff(udi, N)*udi for udi in ud])
+R_star_udot = sum([R_star.diff(udi, N)*udi for udi in ud], Vector(0))
+T_star_udot = sum([T_star.diff(udi, N)*udi for udi in ud], Vector(0))
 for ui in u:
   assert(R_star_udot.diff(ui, N) == 0)
   assert(T_star_udot.diff(ui, N) == 0)
@@ -240,6 +240,5 @@ output_code = re.sub(r"qd([01234])", r"dxdt[\1]", output_code)
 output_code = re.sub(r"u([012])", r"x[\1 + 5]", output_code)
 output_code = re.sub(r"ud([012])", r"dxdt[\1 + 5]", output_code)
 
-f = file("paraboloid_no_slip.txt", 'w')
-f.write(output_code)
-f.close()
+with open("paraboloid_no_slip.txt", 'w') as f:
+    f.write(output_code)


### PR DESCRIPTION
Fixes #215.

All python files run and cpp executables build. I did not test the executables themselves.

Please review the changes to the python files in commit a2d5cb2947eab8b61ad894fbe5dcef7677ef9c9a

The range of the double for loops was reduced from 8 to 5 as @hazelnusse probably intended to do so in  this change 940031574e9ecfd8cce32257892f13eff809742d but forgot. The commit shows that the size of the state is reduced from 8 to 5.

I also set the velocity of points O and RO so please verify that the values are correct.

In the second commit 64afea271431235fcd9109dfe5565b98d844b20d
It looks like @hazelnusse forgot to add some source files so I commented out the relevant section in CMakeLists files.

- [x] There are no merge conflicts.
- [x] If there is a related issue, a reference to that issue is in the
  commit message.
- [x] Unit tests have been added for the bug. (Please reference the issue #
  in the unit test.)
- [x] The tests pass both locally (run `nosetests`) and on Travis CI.
- [x] The code follows PEP8 guidelines. (use a linter, e.g.
  [pylint](http://www.pylint.org), to check your code)
- [ ] The bug fix is documented in the [Release
  Notes](https://github.com/pydy/pydy#release-notes).
- [x] The code is backwards compatible. (All public methods/classes must
  follow deprecation cycles.)
- [x] All reviewer comments have been addressed.