### PR TITLE
Support Python 3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,6 @@ nosetests.xml
 .project
 .pydevproject
 .idea/
+
+# vim swap files
+*.swp

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,11 @@ install:
   - conda create -q -n test-env python=$TRAVIS_PYTHON_VERSION pip coverage nose sphinx numpydoc flake8
   - source activate test-env
   - if [[ $DEP_VERSIONS == "oldest" ]]; then
-      conda install numpy==1.7.0 scipy==0.11.0 sympy==0.7.4.1 cython==0.17 theano==0.6.0;
+      if [[ $TRAVIS_PYTHON_VERSION == 2.7 ]]; then
+        conda install numpy==1.7.0 scipy==0.11.0 sympy==0.7.4.1 cython==0.17 theano==0.6.0;
+      else
+        conda install numpy==1.9 scipy==0.14.0 sympy==0.7.5 cython==0.20.1 theano==0.7.0;
+      fi
     elif [[ $DEP_VERSIONS == "latest" ]]; then
       conda install numpy scipy sympy cython theano;
     elif [[ $DEP_VERSIONS == "master" ]]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,8 @@ env:
   - DEP_VERSIONS="master"
 python:
   - 2.7
+  - 3.3
+  - 3.4
 before_install:
   - sudo apt-get update
   - wget https://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O miniconda.sh

--- a/README.rst
+++ b/README.rst
@@ -55,21 +55,23 @@ analyses, simulation, and visualization.
 Installation
 ============
 
-PyDy has hard dependencies on the following software:
+PyDy has hard dependencies on the following software\[#]_:
 
-- Python >= 2.7, < 3
+- Python >= 2.7, >= 3.3
 - setuptools\ [#]_
-- SymPy_ >= 0.7.4.1
-- NumPy_ >= 1.7
-- SciPy_ >= 0.11.0
+- NumPy_ >= 1.7 (>= 1.9 with Python >= 3.3)
+- SciPy_ >= 0.11.0 (>= 0.14.0 with Python >= 3.3)
+- SymPy_ >= 0.7.4.1 (>= 0.7.5 with Python >= 3.3)
 
+.. [#] We only test PyDy with these minimum dependencies. Previous versions may
+   work.
 .. [#] setuptools >= 8.0 is required if development versions of SymPy are used.
 
 PyDy has optional dependencies on these packages:
 
 - IPython_ >= 0.2.0
-- Cython_ >= 0.17
-- Theano_ >= 0.6.0
+- Theano_ >= 0.6.0 (>= 0.7.0 with Python >= 3.3)
+- Cython_ >= 0.17 (>= 0.20.1 with Python >= 3.3)
 
 .. _Theano: http://deeplearning.net/software/theano/
 .. _Cython: http://cython.org/
@@ -336,7 +338,7 @@ message to our public `mailing list`_ or visit our `Gitter chatroom`_.
 If you think there’s a bug or you would like to request a feature, please open
 an `issue`_ on Github.
 
-.. _issue: https://github.com/pydy/issues
+.. _issue: https://github.com/pydy/pydy/issues
 
 Release Notes
 =============
@@ -347,6 +349,7 @@ Release Notes
 User Facing
 ~~~~~~~~~~~
 
+- Added support Python 3.3 and 3.4. [PR `#38`_]
 - Bumped up the minimum dependencies for NumPy, SciPy, and Cython.
 - Removed the partial implementation of the Mesh shape. [PR `#172`_]
 - Overhauled the code generation package to make the generators more easily
@@ -373,6 +376,7 @@ User Facing
 - Added a new System class and module to more seamlessly manage integrating the
   equations of motion. [PR `#81`_]
 
+.. _#38: https://github.com/pydy/pydy/pull/38
 .. _#172: https://github.com/pydy/pydy/pull/172
 .. _#113: https://github.com/pydy/pydy/pull/113
 .. _#82: https://github.com/pydy/pydy/pull/82

--- a/pydy/codegen/code.py
+++ b/pydy/codegen/code.py
@@ -3,28 +3,33 @@
 """This module remains for backwards compatibility reasons and will be
 removed in PyDy 0.4.0."""
 
+from pkg_resources import parse_version
 import warnings
 
+import pydy
+from ..utils import PyDyDeprecationWarning
 from .ode_function_generators import generate_ode_function as new_gen_ode_func
 
-with warnings.catch_warnings():
-    warnings.simplefilter('once')
-    warnings.warn("This module, 'pydy.codgen.code', is deprecated. The "
-                  "function 'generate_ode_function' can be found in the "
-                  "'pydy.codegen.ode_function_generator' module. "
-                  "'CythonGenerator' has been removed, use "
-                  "'pydy.codegen.cython_code.CythonMatrixGenerator' "
-                  "instead.",
-                  DeprecationWarning)
+
+if parse_version(pydy.__version__) > parse_version('0.4.0'):
+    msg = ("This module, 'pydy.codegen.code', is no longer supported. "
+           "Please remove this module.")
+    raise ValueError(msg)
+
+warnings.warn("This module, 'pydy.codgen.code', is deprecated. The "
+              "function 'generate_ode_function' can be found in the "
+              "'pydy.codegen.ode_function_generator' module. "
+              "'CythonGenerator' has been removed, use "
+              "'pydy.codegen.cython_code.CythonMatrixGenerator' "
+              "instead.",
+              PyDyDeprecationWarning)
 
 
 class CythonGenerator(object):
     def __init__(self, *args, **kwargs):
-        with warnings.catch_warnings():
-            warnings.simplefilter('once')
-            warnings.warn("'CythonGenerator' has been removed, use "
-                          "'pydy.codegen.cython_code.CythonMatrixGenerator' "
-                          "instead.", DeprecationWarning)
+        warnings.warn("'CythonGenerator' has been removed, use "
+                      "'pydy.codegen.cython_code.CythonMatrixGenerator' "
+                      "instead.", PyDyDeprecationWarning)
 
 
 def generate_ode_function(mass_matrix, forcing_vector, constants,
@@ -60,12 +65,10 @@ def generate_ode_function(mass_matrix, forcing_vector, constants,
         A function which evaluates the derivaties of the states.
 
     """
-    with warnings.catch_warnings():
-        warnings.simplefilter('once')
-        warnings.warn("This function is deprecated and will be removed in "
-                      "PyDy 0.4.0. Use the the new 'generate_ode_function' "
-                      "in 'pydy.codegen.ode_function_generator'",
-                      DeprecationWarning)
+    warnings.warn("This function is deprecated and will be removed in PyDy "
+                  "0.4.0. Use the the new 'generate_ode_function' in "
+                  "'pydy.codegen.ode_function_generator'",
+                  PyDyDeprecationWarning)
 
     return new_gen_ode_func(forcing_vector, coordinates, speeds, constants,
                             mass_matrix=mass_matrix, specifieds=specified,

--- a/pydy/codegen/ode_function_generators.py
+++ b/pydy/codegen/ode_function_generators.py
@@ -5,8 +5,8 @@ if sys.version_info > (3, 0):
     from collections.abc import Sequence
 else:
     from collections import Sequence
-from pkg_resources import parse_version
 from itertools import chain
+from pkg_resources import parse_version
 import warnings
 
 import numpy as np
@@ -20,7 +20,12 @@ theano = sm.external.import_module('theano')
 if theano:
     from sympy.printing.theanocode import theano_function
 
+import pydy
+from ..utils import PyDyDeprecationWarning
 from .cython_code import CythonMatrixGenerator
+
+
+warnings.simplefilter('once', PyDyDeprecationWarning)
 
 
 class ODEFunctionGenerator(object):
@@ -374,6 +379,10 @@ r : dictionary
         the key 'constants'. It may also contain a key 'specified'."""
 
         # DEPRECATED : Remove before 0.4.0 release.
+        if parse_version(pydy.__version__) > parse_version('0.4.0'):
+            msg = ("The old style args, i.e. {'constants': , 'specified'}, "
+                    "for the generated function is no longer supported as "
+                    "of PyDy 0.4.0. Please remove this function.")
 
         last_arg = args[-1]
         try:
@@ -382,11 +391,10 @@ r : dictionary
         except (KeyError, IndexError, ValueError):
             return args
         else:
-            with warnings.catch_warnings():
-                warnings.simplefilter('once')
-                warnings.warn("The old style args, i.e. {'constants': , "
-                              "'specified'}, for the generated function will "
-                              "be removed in PyDy 0.4.0.", DeprecationWarning)
+            warnings.warn("The old style args, i.e. {'constants': , "
+                          "'specified'}, for the generated function will be "
+                          "removed in PyDy 0.4.0.",
+                          PyDyDeprecationWarning)
 
             new_args = list(args[:-1])  # gets x and t
 

--- a/pydy/codegen/tests/test_c_code.py
+++ b/pydy/codegen/tests/test_c_code.py
@@ -25,7 +25,7 @@ class TestCMatrixGenerator():
         self.arguments = (list(sm.ordered(sys.constants_symbols)),
                           sys.coordinates,
                           sys.speeds,
-                          sys.specifieds_symbols)
+                          list(sm.ordered(sys.specifieds_symbols)))
 
         self.generator = CMatrixGenerator(self.arguments, self.matrices)
 
@@ -47,7 +47,7 @@ class TestCMatrixGenerator():
          m4, m5) = self.arguments[0]
         x0, x1, x2, x3, x4, x5 = self.arguments[1]
         v0, v1, v2, v3, v4, v5 = self.arguments[2]
-        f5, f2, f3, f0, f4, f1 = self.arguments[3]
+        f0, f1, f2, f3, f4, f5 = self.arguments[3]
 
         expected_subexprs = [
             (pd[0], m4 + m5),
@@ -103,7 +103,7 @@ class TestCMatrixGenerator():
                      'm0, m1, m2, m3, m4, m5'),
                     'x0(t), x1(t), x2(t), x3(t), x4(t), x5(t)',
                     'v0(t), v1(t), v2(t), v3(t), v4(t), v5(t)',
-                    'f5(t), f2(t), f3(t), f0(t), f4(t), f1(t)')
+                    'f0(t), f1(t), f2(t), f3(t), f4(t), f5(t)')
 
         assert self.generator.comma_lists() == expected
 
@@ -131,7 +131,7 @@ input_0[19] : [c0, c1, c2, c3, c4, c5, g, k0, k1, k2, k3, k4, k5, m0, m1, m2,
 m3, m4, m5]
 input_1[6] : [x0(t), x1(t), x2(t), x3(t), x4(t), x5(t)]
 input_2[6] : [v0(t), v1(t), v2(t), v3(t), v4(t), v5(t)]
-input_3[6] : [f5(t), f2(t), f3(t), f0(t), f4(t), f1(t)]\
+input_3[6] : [f0(t), f1(t), f2(t), f3(t), f4(t), f5(t)]\
 """
 
         expected['subexprs'] = \
@@ -140,16 +140,16 @@ input_3[6] : [f5(t), f2(t), f3(t), f0(t), f4(t), f1(t)]\
     double pydy_1 = input_0[16] + pydy_0;
     double pydy_2 = input_0[15] + pydy_1;
     double pydy_3 = input_0[14] + pydy_2;
-    double pydy_4 = input_3[1];
-    double pydy_5 = input_3[2];
+    double pydy_4 = input_3[2];
+    double pydy_5 = input_3[3];
     double pydy_6 = input_3[4];
-    double pydy_7 = input_3[0];
+    double pydy_7 = input_3[5];
     double pydy_8 = input_0[6]*input_0[15];
     double pydy_9 = input_0[6]*input_0[16];
     double pydy_10 = input_0[6]*input_0[17];
     double pydy_11 = input_0[6]*input_0[18];
     double pydy_12 = input_0[6]*input_0[14] + pydy_10 + pydy_11 + pydy_4 +
-    pydy_5 + pydy_6 + pydy_7 + pydy_8 + pydy_9 + input_3[5];\
+    pydy_5 + pydy_6 + pydy_7 + pydy_8 + pydy_9 + input_3[1];\
 """
 
 
@@ -193,7 +193,7 @@ input_3[6] : [f5(t), f2(t), f3(t), f0(t), f4(t), f1(t)]\
     output_0[35] = input_0[18];
 
     output_1[0] = -input_0[0]*input_2[0] + input_0[6]*input_0[13] -
-    input_0[7]*input_1[0] + pydy_12 + input_3[3];
+    input_0[7]*input_1[0] + pydy_12 + input_3[0];
     output_1[1] = -input_0[1]*input_2[1] - input_0[8]*input_1[1] + pydy_12;
     output_1[2] = -input_0[2]*input_2[2] - input_0[9]*input_1[2] + pydy_10 +
     pydy_11 + pydy_4 + pydy_5 + pydy_6 + pydy_7 + pydy_8 + pydy_9;
@@ -228,7 +228,7 @@ input_0[19] : [c0, c1, c2, c3, c4, c5, g, k0, k1, k2, k3, k4, k5, m0, m1, m2,
 m3, m4, m5]
 input_1[6] : [x0(t), x1(t), x2(t), x3(t), x4(t), x5(t)]
 input_2[6] : [v0(t), v1(t), v2(t), v3(t), v4(t), v5(t)]
-input_3[6] : [f5(t), f2(t), f3(t), f0(t), f4(t), f1(t)]
+input_3[6] : [f0(t), f1(t), f2(t), f3(t), f4(t), f5(t)]
 
 */\
 """
@@ -251,16 +251,16 @@ void evaluate(
     double pydy_1 = input_0[16] + pydy_0;
     double pydy_2 = input_0[15] + pydy_1;
     double pydy_3 = input_0[14] + pydy_2;
-    double pydy_4 = input_3[1];
-    double pydy_5 = input_3[2];
+    double pydy_4 = input_3[2];
+    double pydy_5 = input_3[3];
     double pydy_6 = input_3[4];
-    double pydy_7 = input_3[0];
+    double pydy_7 = input_3[5];
     double pydy_8 = input_0[6]*input_0[15];
     double pydy_9 = input_0[6]*input_0[16];
     double pydy_10 = input_0[6]*input_0[17];
     double pydy_11 = input_0[6]*input_0[18];
     double pydy_12 = input_0[6]*input_0[14] + pydy_10 + pydy_11 + pydy_4 +
-    pydy_5 + pydy_6 + pydy_7 + pydy_8 + pydy_9 + input_3[5];
+    pydy_5 + pydy_6 + pydy_7 + pydy_8 + pydy_9 + input_3[1];
 
     output_0[0] = input_0[13] + pydy_3;
     output_0[1] = pydy_3;
@@ -300,7 +300,7 @@ void evaluate(
     output_0[35] = input_0[18];
 
     output_1[0] = -input_0[0]*input_2[0] + input_0[6]*input_0[13] -
-    input_0[7]*input_1[0] + pydy_12 + input_3[3];
+    input_0[7]*input_1[0] + pydy_12 + input_3[0];
     output_1[1] = -input_0[1]*input_2[1] - input_0[8]*input_1[1] + pydy_12;
     output_1[2] = -input_0[2]*input_2[2] - input_0[9]*input_1[2] + pydy_10 +
     pydy_11 + pydy_4 + pydy_5 + pydy_6 + pydy_7 + pydy_8 + pydy_9;

--- a/pydy/codegen/tests/test_code.py
+++ b/pydy/codegen/tests/test_code.py
@@ -21,7 +21,7 @@ class TestCodeRHSArgs():
         sys = n_link_pendulum_on_cart(3, True, True)
 
         constants = sys.constants_symbols
-        specifieds = sys.specifieds_symbols
+        specifieds = tuple(sys.specifieds_symbols)
 
         args = (sys.eom_method.mass_matrix_full,
                 sys.eom_method.forcing_full,
@@ -42,7 +42,7 @@ class TestCodeRHSArgs():
         xd_01 = rhs(x, 0.0, rhs_args)
 
         rhs_args['specified'] = {
-            tuple(specifieds): lambda x, t: np.array([1.0, 2.0, 3.0, 4.0])}
+            specifieds: lambda x, t: np.array([1.0, 2.0, 3.0, 4.0])}
 
         xd_02 = rhs(x, 0.0, rhs_args)
 
@@ -79,7 +79,7 @@ class TestCode():
                 system.coordinates,
                 system.speeds)
 
-        kwargs = {'specified': system.specifieds_symbols}
+        kwargs = {'specified': tuple(system.specifieds_symbols)}
 
         mass_matrix, forcing_vector, constants, coordinates, speeds = args
         specifieds = kwargs['specified']

--- a/pydy/system.py
+++ b/pydy/system.py
@@ -183,7 +183,9 @@ class System(object):
 
     @property
     def constants_symbols(self):
-        """The symbolic constants (not functions of time) in the system."""
+        """A set of the symbolic constants (not functions of time) in the
+        system.
+        """
         return self._constants_symbols
 
     def _check_constants(self, constants):
@@ -252,7 +254,7 @@ class System(object):
 
     @property
     def specifieds_symbols(self):
-        """The dynamicsymbols you must specify."""
+        """A set of the dynamicsymbols you must specify."""
         # TODO : Eventually use a method in the KanesMethod class.
         return self._specifieds_symbols
 
@@ -578,9 +580,9 @@ class System(object):
             for expr in from_eoms:
                 functions_of_time = functions_of_time.union(
                     find_dynamicsymbols(expr))
-            return list(functions_of_time.difference(from_sym_lists))
+            return functions_of_time.difference(from_sym_lists)
         else:
-            return list(self.eom_method._find_dynamicsymbols(
+            return set(self.eom_method._find_dynamicsymbols(
                 *self._Kane_inlist_insyms()))
 
     def _Kane_constant_symbols(self):
@@ -597,9 +599,9 @@ class System(object):
             unique_symbols = set()
             for expr in from_eoms:
                 unique_symbols = unique_symbols.union(expr.free_symbols)
-            constants = list(unique_symbols)
+            constants = unique_symbols
         else:
-            constants = list(self.eom_method._find_othersymbols(
+            constants = set(self.eom_method._find_othersymbols(
                 *self._Kane_inlist_insyms()))
         constants.remove(dynamicsymbols._t)
         return constants

--- a/pydy/system.py
+++ b/pydy/system.py
@@ -51,6 +51,8 @@ you must call ``generate_ode_function`` on your own::
 
 """
 
+from itertools import repeat
+
 import sympy as sm
 from sympy.physics.mechanics import dynamicsymbols
 from scipy.integrate import odeint
@@ -191,9 +193,10 @@ class System(object):
                 raise ValueError("Symbol {} is not a constant.".format(k))
 
     def _constants_padded_with_defaults(self):
-        return dict(self.constants.items() + {
-            s: 1.0 for s in self.constants_symbols if s not in
-            self.constants}.items())
+        d = dict(zip(self.constants_symbols,
+                     repeat(1.0, len(self.constants_symbols))))
+        d.update(self.constants)
+        return d
 
     @property
     def specifieds(self):
@@ -321,9 +324,10 @@ class System(object):
         return False
 
     def _specifieds_padded_with_defaults(self):
-        return dict(self.specifieds.items() + {
-            s: 0.0 for s in self.specifieds_symbols if not
-            self._symbol_is_in_specifieds_dict(s, self.specifieds)}.items())
+        d = dict(zip(self.specifieds_symbols,
+                     repeat(0.0, len(self.specifieds_symbols))))
+        d.update(self.specifieds)
+        return d
 
     @property
     def times(self):
@@ -393,8 +397,10 @@ class System(object):
                 raise ValueError("Symbol {} is not a state.".format(k))
 
     def _initial_conditions_padded_with_defaults(self):
-        d = {s: 0.0 for s in self.states if s not in self.initial_conditions}
-        return dict(self.initial_conditions.items() + d.items())
+        d = dict(zip(self.states,
+                     repeat(0.0, len(self.states))))
+        d.update(self.initial_conditions)
+        return d
 
     @property
     def evaluate_ode_function(self):

--- a/pydy/tests/test_models.py
+++ b/pydy/tests/test_models.py
@@ -1,9 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-# standard libraries
-from collections import Counter
-
 # external libraries
 import sympy as sm
 import sympy.physics.mechanics as me
@@ -19,8 +16,8 @@ def test_multi_mass_spring_damper():
 
     sys = multi_mass_spring_damper()
 
-    assert Counter(sys.constants_symbols) == Counter([k0, c0, m0])
-    assert sys.specifieds_symbols == list()
+    assert sys.constants_symbols == {k0, c0, m0}
+    assert sys.specifieds_symbols == set()
     assert sys.coordinates == [x0]
     assert sys.speeds == [v0]
     assert sys.states == [x0, v0]
@@ -43,8 +40,8 @@ def test_multi_mass_spring_damper_with_forces():
     sys = multi_mass_spring_damper(apply_gravity=True,
                                    apply_external_forces=True)
 
-    assert Counter(sys.constants_symbols) == Counter([k0, m0, g, c0])
-    assert sys.specifieds_symbols == [f0]
+    assert sys.constants_symbols == {k0, m0, g, c0}
+    assert sys.specifieds_symbols == {f0}
     assert sys.coordinates == [x0]
     assert sys.speeds == [v0]
     assert sys.states == [x0, v0]
@@ -66,9 +63,9 @@ def test_multi_mass_spring_damper_double():
 
     sys = multi_mass_spring_damper(2, True, True)
 
-    assert Counter(sys.constants_symbols) == \
-        Counter([c1, m1, k0, c0, k1, g, m0])
-    assert sys.specifieds_symbols == [f0, f1]
+    assert sys.constants_symbols == \
+        {c1, m1, k0, c0, k1, g, m0}
+    assert sys.specifieds_symbols == {f0, f1}
     assert sys.coordinates == [x0, x1]
     assert sys.speeds == [v0, v1]
     assert sys.states == [x0, x1, v0, v1]

--- a/pydy/tests/test_system.py
+++ b/pydy/tests/test_system.py
@@ -60,13 +60,15 @@ class TestSystem():
                      constants=self.constant_map)
 
         assert sys.eom_method is self.kane
-        assert sys.specifieds.keys() == [dynamicsymbols('f0')]
-        testing.assert_allclose(sys.specifieds.values(), [np.ones(1)])
+        assert list(sys.specifieds.keys()) == [dynamicsymbols('f0')]
+        testing.assert_allclose(list(sys.specifieds.values()),
+                                [np.ones(1)])
         assert sys.initial_conditions.keys() == ic.keys()
-        testing.assert_allclose(sys.initial_conditions.values(), ic.values())
+        testing.assert_allclose(list(sys.initial_conditions.values()),
+                                list(ic.values()))
         assert sys.constants.keys() == self.constant_map.keys()
-        testing.assert_allclose(sys.constants.values(),
-                                self.constant_map.values())
+        testing.assert_allclose(list(sys.constants.values()),
+                                list(self.constant_map.values()))
 
         # Use old specifieds.
         # -------------------
@@ -107,7 +109,8 @@ class TestSystem():
         sys = System(self.kane, constants=constants)
 
         assert sys.constants.keys() == constants.keys()
-        testing.assert_allclose(sys.constants.values(), constants.values())
+        testing.assert_allclose(list(sys.constants.values()),
+                                list(constants.values()))
 
         # Set constants after construction.
         # ---------------------------------
@@ -118,15 +121,16 @@ class TestSystem():
         sys.constants = constants
 
         assert sys.constants.keys() == constants.keys()
-        testing.assert_allclose(sys.constants.values(), constants.values())
+        testing.assert_allclose(list(sys.constants.values()),
+                                list(constants.values()))
 
         # Using the property as a dict.
         # -----------------------------
         sys = System(self.kane)
         # Modifying the dict directly does change the dict.
         sys.constants[sm.symbols('m0')] = 9.3
-        assert sys.constants.keys() == [sm.symbols('m0')]
-        testing.assert_allclose(sys.constants.values(), [9.3])
+        assert list(sys.constants.keys()) == [sm.symbols('m0')]
+        testing.assert_allclose(list(sys.constants.values()), [9.3])
 
         # Putting in a non-constant key does not raise exception.
         sys.constants[dynamicsymbols('v0')] = 9.8
@@ -147,15 +151,15 @@ class TestSystem():
         sys = System(self.kane)
         assert sys.specifieds == dict()
         sys.specifieds = {dynamicsymbols('f0'): 5.9}
-        assert sys.specifieds.keys() == [dynamicsymbols('f0')]
-        testing.assert_allclose(sys.specifieds.values(), [5.9])
+        assert list(sys.specifieds.keys()) == [dynamicsymbols('f0')]
+        testing.assert_allclose(list(sys.specifieds.values()), [5.9])
 
         # Using the property as a dict.
         # -----------------------------
         # Modifying the dict directly does change the dict.
         sys.specifieds[dynamicsymbols('f0')] = 5.1
-        assert sys.specifieds.keys() == [dynamicsymbols('f0')]
-        testing.assert_allclose(sys.specifieds.values(), [5.1])
+        assert list(sys.specifieds.keys()) == [dynamicsymbols('f0')]
+        testing.assert_allclose(list(sys.specifieds.values()), [5.1])
         # Putting in a non-specified key does not raise exception.
         sys.specifieds[dynamicsymbols('v0')] = 3.5
         # Then, if we integrate, we do error-checking and we get an exception.
@@ -274,22 +278,24 @@ class TestSystem():
         # ----------------------
         sys = System(self.kane, initial_conditions=ic)
         assert sys.initial_conditions.keys() == ic.keys()
-        testing.assert_allclose(sys.initial_conditions.values(), ic.values())
+        testing.assert_allclose(list(sys.initial_conditions.values()),
+                                list(ic.values()))
 
         # Set the attribute.
         # ------------------
         sys = System(self.kane)
         sys.initial_conditions = ic
         assert sys.initial_conditions.keys() == ic.keys()
-        testing.assert_allclose(sys.initial_conditions.values(), ic.values())
+        testing.assert_allclose(list(sys.initial_conditions.values()),
+                                list(ic.values()))
 
         # Using the property as a dict.
         # -----------------------------
         # Modifying hte dict directly does change the dict.
         sys = System(self.kane, times=[0.0, 1.0])
         sys.initial_conditions[dynamicsymbols('x0')] = 5.8
-        assert sys.initial_conditions.keys() == [dynamicsymbols('x0')]
-        testing.assert_allclose(sys.initial_conditions.values(), [5.8])
+        assert list(sys.initial_conditions.keys()) == [dynamicsymbols('x0')]
+        testing.assert_allclose(list(sys.initial_conditions.values()), [5.8])
         # Putting in a non-state key does not raise exception.
         sys.initial_conditions[sm.symbols('m0')] = 7.9
         # Then, if we integrate, we do error-checking and we get an exception.

--- a/pydy/tests/test_system.py
+++ b/pydy/tests/test_system.py
@@ -1,7 +1,5 @@
 #!/usr/bin/env python
 
-from collections import Counter
-
 import numpy as np
 from numpy import testing
 import sympy as sm
@@ -22,7 +20,7 @@ class TestSystem():
         # Create a simple system with one specified quantity.
         self.sys = multi_mass_spring_damper(1, apply_gravity=True,
                                             apply_external_forces=True)
-        self.specified_symbol = self.sys.specifieds_symbols[0]
+        self.specified_symbol = next(iter(self.sys.specifieds_symbols))
         self.constant_map = dict(zip(sm.symbols('m0, k0, c0, g'),
                                      [2.0, 1.5, 0.5, 9.8]))
         self.sys.specifieds = {self.specified_symbol: np.ones(1)}
@@ -39,9 +37,9 @@ class TestSystem():
         # -----------------------------------
         sys = System(self.kane)
 
-        assert (Counter(sys.constants_symbols) ==
-                Counter(list(sm.symbols('k0, m0, g, c0'))))
-        assert sys.specifieds_symbols == [self.specified_symbol]
+        assert (sys.constants_symbols ==
+                set(sm.symbols('k0, m0, g, c0')))
+        assert sys.specifieds_symbols == {self.specified_symbol}
         assert sys.states == dynamicsymbols('x0, v0')
         assert sys.evaluate_ode_function is None
         assert sys.eom_method is self.kane
@@ -187,7 +185,7 @@ class TestSystem():
         # Complex error-checking when using property as a dict.
         # -----------------------------------------------------
         sys = System(self.kane_nlink)
-        spec_syms = sys.specifieds_symbols
+        spec_syms = list(sys.specifieds_symbols)
         times = np.linspace(0, 0.5, 10)
         sys.specifieds = {
             spec_syms[0]: lambda x, t: np.ones(t),
@@ -216,7 +214,7 @@ class TestSystem():
         # Test old way of providing specifieds.
         # -------------------------------------
         sys = System(self.kane_nlink)
-        spec_syms = sys.specifieds_symbols
+        spec_syms = list(sys.specifieds_symbols)
         # Get numbers using the new way.
         sys.specifieds = dict(zip(spec_syms, [1.0, 2.0, 3.0, 4.0]))
         sys.times = times
@@ -326,7 +324,7 @@ class TestSystem():
         # n-link cart: play with specifieds.
         # ----------------------------------
         sys = System(self.kane_nlink)
-        spec_syms = sys.specifieds_symbols
+        spec_syms = list(sys.specifieds_symbols)
         rhs = sys.generate_ode_function()
         x = np.array(np.random.random(len(sys.states)))
         args = (self.sys.specifieds,

--- a/pydy/utils.py
+++ b/pydy/utils.py
@@ -29,7 +29,7 @@ def sympy_equal_to_or_newer_than(version, installed_version=None):
                'setuptools < 8.0 or a newer development version of SymPy.')
         raise ValueError(msg.format(v))
 
-    return cmp(parse_version(v), parse_version(version)) > -1
+    return parse_version(v) >= parse_version(version)
 
 
 def wrap_and_indent(lines, indentation=4, width=79):

--- a/pydy/utils.py
+++ b/pydy/utils.py
@@ -75,3 +75,7 @@ def find_dynamicsymbols(expression, exclude=None):
         exclude_set = set()
     return set([i for i in expression.atoms(AppliedUndef, sm.Derivative) if
                 i.free_symbols == t_set]) - exclude_set
+
+
+class PyDyDeprecationWarning(DeprecationWarning):
+    pass

--- a/pydy/viz/__init__.py
+++ b/pydy/viz/__init__.py
@@ -11,25 +11,26 @@ __all__ = []
 #    determine which names are imported when
 #    "from sympy.physics.mechanics import *" is done.
 
-import visualization_frame
+from . import visualization_frame
 from .visualization_frame import *
 __all__.extend(visualization_frame.__all__)
 
-import shapes
+from . import shapes
 from .shapes import *
 __all__.extend(shapes.__all__)
 
-import scene
+from . import scene
 from .scene import *
 __all__.extend(scene.__all__)
 
-import camera
+from . import camera
 from .camera import *
 __all__.extend(camera.__all__)
 
-import light
+from . import light
 from .light import *
 __all__.extend(light.__all__)
 
-import server
+from . import server
 from .server import *
+__all__.extend(server.__all__)

--- a/pydy/viz/scene.py
+++ b/pydy/viz/scene.py
@@ -585,7 +585,7 @@ class Scene(object):
             self._fill_constants_widgets()
             # Add all of the constants widgets to the container.
             self._constants_container.children = \
-                self._constants_text_widgets.values()
+                tuple(v for v in self._constants_text_widgets.values())
 
             self._initialize_rerun_button()
 

--- a/pydy/viz/scene.py
+++ b/pydy/viz/scene.py
@@ -397,7 +397,7 @@ class Scene(object):
                 distutils.dir_util.remove_tree(dst)
             else:
                 if not silent:
-                    print "Aborted!"
+                    print("Aborted!")
                 return
 
         src = os.path.join(os.path.dirname(__file__), 'static')
@@ -441,7 +441,7 @@ class Scene(object):
 
         """
         if not os.path.exists('static'):
-            print "All Done!"
+            print("All Done!")
             return
 
         if not force:
@@ -453,9 +453,9 @@ class Scene(object):
         if force:
             distutils.dir_util.remove_tree(os.path.join(os.getcwd(),
                                                         'static'))
-            print "All Done!"
+            print("All Done!")
         else:
-            print "aborted!"
+            print("aborted!")
 
     def display(self):
         """Displays the scene in the default webbrowser."""

--- a/pydy/viz/scene.py
+++ b/pydy/viz/scene.py
@@ -20,6 +20,11 @@ from .server import run_server
 from .light import PointLight
 from ..system import System
 
+import sys
+if sys.version_info > (3, 0):
+    raw_input = input
+
+
 __all__ = ['Scene']
 
 try:
@@ -392,7 +397,7 @@ class Scene(object):
 
         if os.path.exists(dst) and overwrite is False:
             ans = raw_input("The 'static' directory already exists. Would "
-                            + "you like to overwrite the contents? [y|n]\n")
+                            "you like to overwrite the contents? [y|n]\n")
             if ans == 'y':
                 distutils.dir_util.remove_tree(dst)
             else:

--- a/pydy/viz/server.py
+++ b/pydy/viz/server.py
@@ -16,11 +16,11 @@ def run_server(port=8000,scene_file="Null"):
     HandlerClass.protocol_version = Protocol
     httpd = ServerClass(server_address, HandlerClass)
     sa = httpd.socket.getsockname()
-    print "Serving HTTP on", sa[0], "port", sa[1], "..."
-    print "hit ctrl+c to stop the server.."
-    print "To view visualization, open:\n"
-    url = "http://localhost:"+str(sa[1]) + "/index.html?load="+scene_file
-    print url
+    print("Serving HTTP on", sa[0], "port", sa[1], "...")
+    print("hit ctrl+c to stop the server..")
+    print("To view visualization, open:\n")
+    url = "http://localhost:"+ str(sa[1]) + "/index.html?load=" + scene_file
+    print(url)
     webbrowser.open(url)
     httpd.serve_forever()
 

--- a/pydy/viz/server.py
+++ b/pydy/viz/server.py
@@ -5,6 +5,8 @@ import webbrowser
 import BaseHTTPServer
 from SimpleHTTPServer import SimpleHTTPRequestHandler
 
+__all__ = ['run_server']
+
 
 def run_server(port=8000,scene_file="Null"):
     #change dir to static first.

--- a/pydy/viz/server.py
+++ b/pydy/viz/server.py
@@ -1,9 +1,15 @@
 #!/usr/bin/env python
 
 import os
+import sys
 import webbrowser
-import BaseHTTPServer
-from SimpleHTTPServer import SimpleHTTPRequestHandler
+if sys.version_info < (3, 0):
+    from SimpleHTTPServer import SimpleHTTPRequestHandler
+    from BaseHTTPServer import HTTPServer
+else:
+    from http.server import SimpleHTTPRequestHandler
+    from http.server import HTTPServer
+
 
 __all__ = ['run_server']
 
@@ -12,7 +18,7 @@ def run_server(port=8000,scene_file="Null"):
     #change dir to static first.
     os.chdir("static/")
     HandlerClass = SimpleHTTPRequestHandler
-    ServerClass  = BaseHTTPServer.HTTPServer
+    ServerClass  = HTTPServer
     Protocol     = "HTTP/1.0"
     server_address = ('127.0.0.1', port)
     HandlerClass.protocol_version = Protocol

--- a/pydy/viz/visualization_frame.py
+++ b/pydy/viz/visualization_frame.py
@@ -1,5 +1,10 @@
 __all__ = ['VisualizationFrame']
 
+import sys
+if sys.version_info < (3, 0):
+    from collections import Iterator
+else:
+    from collections.abc import Iterator
 import numpy as np
 from sympy import Dummy, lambdify
 from sympy.matrices.expressions import Identity
@@ -255,9 +260,9 @@ class VisualizationFrame(object):
         dummy_symbols = [Dummy() for i in dynamic_variables]
         dummy_dict = dict(zip(dynamic_variables, dummy_symbols))
         transform = self._transform.subs(dummy_dict)
+        dummy_symbols.extend(constant_variables)
 
-        self._numeric_transform = lambdify(dummy_symbols +
-                                           constant_variables, transform,
+        self._numeric_transform = lambdify(dummy_symbols, transform,
                                            modules="numpy")
 
         return self._numeric_transform
@@ -282,6 +287,8 @@ class VisualizationFrame(object):
         #else convert it to one:
 
         states = np.array(dynamic_values)
+        if not isinstance(constant_values, Iterator):
+            constant_values = list(constant_values)
         if len(states.shape) > 1:
             n = states.shape[0]
             new = np.zeros((n, 4, 4))

--- a/setup.py
+++ b/setup.py
@@ -2,6 +2,7 @@
 # -*- coding: utf-8 -*-
 
 import os
+import sys
 
 from setuptools import setup, find_packages
 
@@ -11,6 +12,18 @@ exec(open('pydy/version.py').read())
 # https://github.com/statsmodels/statsmodels/issues/1073, so the following
 # line is added.
 os.environ["MPLCONFIGDIR"] = "."
+
+NUMPY_MIN_VER = '1.7'
+SCIPY_MIN_VER = '0.11'
+SYMPY_MIN_VER = '0.7.4.1'
+CYTHON_MIN_VER = '0.17'
+THEANO_MIN_VER = '0.6.0'
+if sys.version_info >= (3, 0):
+    NUMPY_MIN_VER = '1.9'
+    SCIPY_MIN_VER = '0.14.0'
+    SYMPY_MIN_VER = '0.7.5'
+    CYTHON_MIN_VER = '0.20.1'
+    THEANO_MIN_VER = '0.7.0'
 
 setup(
     name='pydy',
@@ -23,12 +36,13 @@ setup(
     keywords="multibody dynamics",
     license='LICENSE.txt',
     packages=find_packages(),
-    install_requires=['sympy>=0.7.4.1',
-                      'numpy>=1.7',
-                      'scipy>=0.11',
+    install_requires=['numpy>={}'.format(NUMPY_MIN_VER),
+                      'scipy>={}'.format(SCIPY_MIN_VER),
+                      'sympy>={}'.format(SYMPY_MIN_VER),
                       ],
     extras_require={'doc': ['sphinx', 'numpydoc'],
-                    'codegen': ['Cython>=0.17', 'Theano>=0.6.0'],
+                    'codegen': ['Cython>={}'.format(CYTHON_MIN_VER),
+                                'Theano>={}'.format(THEANO_MIN_VER)],
                     'examples': ['matplotlib>=0.99'],
                     },
     tests_require=['nose>=1.3.0'],


### PR DESCRIPTION
Addresses https://github.com/pydy/pydy/issues/38
I got 2 of the examples (mass_spring_damper, three_link_conical_pendulum) to run with Python 3.4.2.

- [x] There are no merge conflicts.
- [x] If there is a related issue, a reference to that issue is in the
  commit message.
- [x] Unit tests have been added for the new feature.
- [x] The PR passes tests both locally (run `nosetests`) and on Travis CI.
- [x] All public methods and classes have docstrings. (We use the [numpydoc
  format](https://github.com/numpy/numpy/blob/master/doc/HOWTO_DOCUMENT.rst.txt).)
- [x] An explanation has been added to the online documentation. (`docs`
  directory)
- [x] The code follows PEP8 guidelines. (use a linter, e.g.
  [pylint](http://www.pylint.org), to check your code)
- [x] The new feature is documented in the [Release
  Notes](https://github.com/pydy/pydy#release-notes).
- [x] The code is backwards compatible. (All public methods/classes must
  follow deprecation cycles.)
- [x] All reviewer comments have been addressed.
