### PR TITLE
Removed the tmp dir in the Cython tests, it is not necessary.

### DIFF
--- a/pydy/codegen/tests/test_cython_code.py
+++ b/pydy/codegen/tests/test_cython_code.py
@@ -160,7 +160,7 @@ setup(name="boogly_bee",
 
     def test_compile(self):
 
-        f = self.generator.compile(tmp_dir='booger')
+        f = self.generator.compile()
 
         subs = {}
 


### PR DESCRIPTION
- [ ] There are no merge conflicts.
- [ ] If there is a related issue, a reference to that issue is in the
  commit message.
- [ ] Unit tests have been added for the bug. (Please reference the issue #
  in the unit test.)
- [ ] The tests pass both locally (run `nosetests`) and on Travis CI.
- [ ] The code follows PEP8 guidelines. (use a linter, e.g.
  [pylint](http://www.pylint.org), to check your code)
- [ ] The bug fix is documented in the [Release
  Notes](https://github.com/pydy/pydy#release-notes).
- [ ] The code is backwards compatible. (All public methods/classes must
  follow deprecation cycles.)
- [ ] All reviewer comments have been addressed.