### PR TITLE
Added shutting down calls to the visualization server

### DIFF
--- a/pydy/viz/scene.py
+++ b/pydy/viz/scene.py
@@ -17,7 +17,7 @@ from sympy.physics.mechanics import ReferenceFrame, Point
 
 # local
 from .camera import PerspectiveCamera
-from .server import run_server
+from .server import Server
 from .light import PointLight
 from ..system import System
 from ..utils import PyDyImportWarning
@@ -463,7 +463,8 @@ class Scene(object):
     def display(self):
         """Displays the scene in the default webbrowser."""
         self.create_static_html()
-        run_server(scene_file=self._scene_json_file)
+        server = Server(scene_file=self._scene_json_file)
+        server.run_server()
 
     def _rerun_button_callback(self, btn):
         """Callback for the "Rerun Simulation" button. When executed the

--- a/pydy/viz/server.py
+++ b/pydy/viz/server.py
@@ -71,18 +71,10 @@ class Server(object):
     >>> server.run_server()
 
     """
-    def __init__(self, scene_file, directory=None, port=None):
+    def __init__(self, scene_file, directory="static/", port=8000):
         self.scene_file = scene_file
-
-        if directory is None:
-            self.directory = directory
-        else:
-            self.directory = "static/"
-
-        if port is None:
-            self.port = port
-        else:
-            self.port = 8000
+        self.port = port
+        self.directory = directory
 
     def run_server(self):
         # Change dir to static first.

--- a/pydy/viz/server.py
+++ b/pydy/viz/server.py
@@ -103,3 +103,5 @@ class Server(object):
             print("Shutdown confirmed")
             print("Shutting down server...")
             self.httpd.stop()
+        else:
+            print("Resuming operations...")

--- a/pydy/viz/server.py
+++ b/pydy/viz/server.py
@@ -71,7 +71,7 @@ class Server(object):
 
     """
     def __init__(self, scene_file, directory=None, port=None):
-        if scene_file
+        if scene_file:
             self.scene_file = scene_file
 
         if directory:

--- a/pydy/viz/server.py
+++ b/pydy/viz/server.py
@@ -86,10 +86,10 @@ class Server(object):
         print(url)
         webbrowser.open(url)
         print("Hit Ctrl+C to stop the server...")
-        signal.signal(signal.SIGINT, self.stop_server)
+        signal.signal(signal.SIGINT, self._stop_server)
         self.httpd.serve()
 
-    def stop_server(self, signal, frame):
+    def _stop_server(self, signal, frame):
         """
         Confirms and stops the visulisation server
         :param signal:

--- a/pydy/viz/server.py
+++ b/pydy/viz/server.py
@@ -57,9 +57,10 @@ class Server(object):
     Parameters
     ----------
     port : integer
-        Defines the port on which the server will run.
+        Defines the port on which the server will run. If this port is
+        already bind, then it increment 1 until it finds a free port.
     scene_file : name of the scene_file generated for visualization
-        A Valid PyDy generated scene file in 'directory'.
+        A Valid PyDy generated scene file in 'directory' parameter.
     directory : absolute path of a directory
         Absolute path to the directory which contains scene_file with
         all other static files.
@@ -73,12 +74,12 @@ class Server(object):
     def __init__(self, scene_file, directory=None, port=None):
         self.scene_file = scene_file
 
-        if directory:
+        if directory is None:
             self.directory = directory
         else:
             self.directory = "static/"
 
-        if port:
+        if port is None:
             self.port = port
         else:
             self.port = 8000
@@ -121,7 +122,7 @@ class Server(object):
 
         """
         res = raw_input("Shutdown this visualization server ([y]/n)? ")
-        res = res.lower()[0:1]
+        res = res.lower()[0]
         if res == '' or res == 'y':
             print("Shutdown confirmed")
             print("Shutting down server...")

--- a/pydy/viz/server.py
+++ b/pydy/viz/server.py
@@ -4,21 +4,27 @@ import os
 import signal
 import socket
 import webbrowser
-import BaseHTTPServer
-from SimpleHTTPServer import SimpleHTTPRequestHandler
 
+# For python 2 and python 3 compatibility
+if sys.version_info < (3, 0):
+    from SimpleHTTPServer import SimpleHTTPRequestHandler
+    from BaseHTTPServer import HTTPServer
+else:
+    from http.server import SimpleHTTPRequestHandler
+    from http.server import HTTPServer
+    raw_input = input
 
 __all__ = ['Server']
 
 
-class StoppableHTTPServer(BaseHTTPServer.HTTPServer):
+class StoppableHTTPServer(HTTPServer):
     """
     Overrides BaseHTTPServer.HTTPServer to include a stop
     function.
     """
 
     def server_bind(self):
-        BaseHTTPServer.HTTPServer.server_bind(self)
+        HTTPServer.server_bind(self)
         self.socket.settimeout(1)
         self.run = True
 
@@ -49,17 +55,17 @@ class Server(object):
     """
     Parameters
     ----------
-    :param port : integer
+    port : integer
         Defines the port on which the server will run.
-    :param scene_file : name of the scene_file generated for visualization
+    scene_file : name of the scene_file generated for visualization
         Used here to display the url
-    :param directory : path of the directory which contains static and scene files.
+    directory : path of the directory which contains static and scene files.
         Server is started in this directory itself.
 
     Example
     -------
-        >>> server = Server(scene_file=_scene_json_file)
-        >>> server.run_server()
+    >>> server = Server(scene_file=_scene_json_file)
+    >>> server.run_server()
 
     """
     def __init__(self, port=8000, scene_file="Null"):
@@ -97,7 +103,7 @@ class Server(object):
 
         """
         res = raw_input("Shutdown this visualization server ([y]/n)? ")
-        if res is (None or 'y'):
+        if res.lower()[0:1] is (None or 'y'):
             print("Shutdown confirmed")
             print("Shutting down server...")
             self.httpd.stop()

--- a/pydy/viz/server.py
+++ b/pydy/viz/server.py
@@ -1,7 +1,5 @@
 #!/usr/bin/env python
 
-from __future__ import print_function
-
 import os
 import signal
 import socket

--- a/pydy/viz/server.py
+++ b/pydy/viz/server.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 
 import os
+import sys
 import signal
 import socket
 import webbrowser
@@ -103,7 +104,8 @@ class Server(object):
 
         """
         res = raw_input("Shutdown this visualization server ([y]/n)? ")
-        if res.lower()[0:1] is (None or 'y'):
+        res = res.lower()[0:1]
+        if res == '' or res == 'y':
             print("Shutdown confirmed")
             print("Shutting down server...")
             self.httpd.stop()

--- a/pydy/viz/server.py
+++ b/pydy/viz/server.py
@@ -71,8 +71,7 @@ class Server(object):
 
     """
     def __init__(self, scene_file, directory=None, port=None):
-        if scene_file:
-            self.scene_file = scene_file
+        self.scene_file = scene_file
 
         if directory:
             self.directory = directory
@@ -110,10 +109,7 @@ class Server(object):
     def _check_port(self, port):
         soc = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         result = soc.connect_ex(('127.0.0.1', port))
-        if result == 0:
-            return True
-        else:
-            return False
+        return result == 0
 
     def _stop_server(self, signal, frame):
         """

--- a/pydy/viz/server.py
+++ b/pydy/viz/server.py
@@ -60,8 +60,6 @@ class Server(object):
         Defines the port on which the server will run.
     scene_file : name of the scene_file generated for visualization
         Used here to display the url
-    directory : path of the directory which contains static and scene files.
-        Server is started in this directory itself.
 
     Example
     -------

--- a/pydy/viz/server.py
+++ b/pydy/viz/server.py
@@ -96,9 +96,9 @@ class Server(object):
     def _stop_server(self, signal, frame):
         """
         Confirms and stops the visulisation server
-        :param signal:
+        signal:
             Required by signal.signal
-        :param frame:
+        frame:
             Required by signal.signal
 
         """

--- a/pydy/viz/server.py
+++ b/pydy/viz/server.py
@@ -59,7 +59,10 @@ class Server(object):
     port : integer
         Defines the port on which the server will run.
     scene_file : name of the scene_file generated for visualization
-        Used here to display the url
+        A Valid PyDy generated scene file in 'directory'.
+    directory : absolute path of a directory
+        Absolute path to the directory which contains scene_file with
+        all other static files.
 
     Example
     -------
@@ -67,14 +70,26 @@ class Server(object):
     >>> server.run_server()
 
     """
-    def __init__(self, port=8000, scene_file="Null"):
-        self.port = port
-        self.scene_file = scene_file
-        self.directory = "static/"
+    def __init__(self, scene_file, directory=None, port=None):
+        if scene_file
+            self.scene_file = scene_file
+
+        if directory:
+            self.directory = directory
+        else:
+            self.directory = "static/"
+
+        if port:
+            self.port = port
+        else:
+            self.port = 8000
 
     def run_server(self):
         # Change dir to static first.
         os.chdir(self.directory)
+        # Get a free port
+        while self._check_port(self.port):
+            self.port += 1
         handler_class = SimpleHTTPRequestHandler
         server_class = StoppableHTTPServer
         protocol = "HTTP/1.0"
@@ -91,6 +106,14 @@ class Server(object):
         print("Hit Ctrl+C to stop the server...")
         signal.signal(signal.SIGINT, self._stop_server)
         self.httpd.serve()
+
+    def _check_port(self, port):
+        soc = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        result = soc.connect_ex(('127.0.0.1', port))
+        if result == 0:
+            return True
+        else:
+            return False
 
     def _stop_server(self, signal, frame):
         """

--- a/pydy/viz/server.py
+++ b/pydy/viz/server.py
@@ -1,37 +1,105 @@
 #!/usr/bin/env python
 
+from __future__ import print_function
+
 import os
-import sys
+import signal
+import socket
 import webbrowser
-if sys.version_info < (3, 0):
-    from SimpleHTTPServer import SimpleHTTPRequestHandler
-    from BaseHTTPServer import HTTPServer
-else:
-    from http.server import SimpleHTTPRequestHandler
-    from http.server import HTTPServer
+import BaseHTTPServer
+from SimpleHTTPServer import SimpleHTTPRequestHandler
 
 
-__all__ = ['run_server']
+__all__ = ['Server']
 
 
-def run_server(port=8000,scene_file="Null"):
-    #change dir to static first.
-    os.chdir("static/")
-    HandlerClass = SimpleHTTPRequestHandler
-    ServerClass  = HTTPServer
-    Protocol     = "HTTP/1.0"
-    server_address = ('127.0.0.1', port)
-    HandlerClass.protocol_version = Protocol
-    httpd = ServerClass(server_address, HandlerClass)
-    sa = httpd.socket.getsockname()
-    print("Serving HTTP on", sa[0], "port", sa[1], "...")
-    print("hit ctrl+c to stop the server..")
-    print("To view visualization, open:\n")
-    url = "http://localhost:"+ str(sa[1]) + "/index.html?load=" + scene_file
-    print(url)
-    webbrowser.open(url)
-    httpd.serve_forever()
+class StoppableHTTPServer(BaseHTTPServer.HTTPServer):
+    """
+    Overrides BaseHTTPServer.HTTPServer to include a stop
+    function.
+    """
+
+    def server_bind(self):
+        BaseHTTPServer.HTTPServer.server_bind(self)
+        self.socket.settimeout(1)
+        self.run = True
+
+    def get_request(self):
+        while self.run:
+            try:
+                sock, addr = self.socket.accept()
+                sock.settimeout(None)
+                return (sock, addr)
+            except socket.timeout:
+                pass
+
+    def stop(self):
+        self.run = False
+
+    def serve(self):
+        while self.run:
+            try:
+                self.handle_request()
+            except TypeError:
+                # When server is being closed, while loop can run once
+                # after setting self.run = False depending on how it
+                # is scheduled.
+                pass
 
 
-if __name__ == "__main__":
-    run_server()
+class Server(object):
+    """
+    Parameters
+    ----------
+    :param port : integer
+        Defines the port on which the server will run.
+    :param scene_file : name of the scene_file generated for visualization
+        Used here to display the url
+    :param directory : path of the directory which contains static and scene files.
+        Server is started in this directory itself.
+
+    Example
+    -------
+        >>> server = Server(scene_file=_scene_json_file)
+        >>> server.run_server()
+
+    """
+    def __init__(self, port=8000, scene_file="Null"):
+        self.port = port
+        self.scene_file = scene_file
+        self.directory = "static/"
+
+    def run_server(self):
+        # Change dir to static first.
+        os.chdir(self.directory)
+        handler_class = SimpleHTTPRequestHandler
+        server_class = StoppableHTTPServer
+        protocol = "HTTP/1.0"
+        server_address = ('127.0.0.1', self.port)
+        handler_class.protocol_version = protocol
+        self.httpd = server_class(server_address, handler_class)
+        sa = self.httpd.socket.getsockname()
+        print("Serving HTTP on", sa[0], "port", sa[1], "...")
+        print("To view visualization, open:\n")
+        url = "http://localhost:"+str(sa[1]) + "/index.html?load=" + \
+              self.scene_file
+        print(url)
+        webbrowser.open(url)
+        print("Hit Ctrl+C to stop the server...")
+        signal.signal(signal.SIGINT, self.stop_server)
+        self.httpd.serve()
+
+    def stop_server(self, signal, frame):
+        """
+        Confirms and stops the visulisation server
+        :param signal:
+            Required by signal.signal
+        :param frame:
+            Required by signal.signal
+
+        """
+        res = raw_input("Shutdown this visualization server ([y]/n)? ")
+        if res is (None or 'y'):
+            print("Shutdown confirmed")
+            print("Shutting down server...")
+            self.httpd.stop()


### PR DESCRIPTION
Fixes #232

- [x] There are no merge conflicts.
- [x] If there is a related issue, a reference to that issue is in the
  commit message.
- [ ] Unit tests have been added for the bug. (Please reference the issue #
  in the unit test.)
- [ ] The tests pass both locally (run `nosetests`) and on Travis CI.
- [x] The code follows PEP8 guidelines. (use a linter, e.g.
  [pylint](http://www.pylint.org), to check your code)
- [ ] The bug fix is documented in the [Release
  Notes](https://github.com/pydy/pydy#release-notes).
- [x] The code is backwards compatible. (All public methods/classes must
  follow deprecation cycles.)
- [x] All reviewer comments have been addressed.