### PR TITLE
Created basic structure of force classes

### DIFF
--- a/pydy/forces.py
+++ b/pydy/forces.py
@@ -1,0 +1,35 @@
+from sympy import Symbol
+
+__all__ = ['Force', 'GravitationalForce']
+
+
+class Force(object):
+    """
+    It provides an concept of force, although actual force is added by system.
+
+    Parameters
+    ---------
+    point: sympy.physics.vector.Point
+        Point of application of force.
+    direction: sympy.physics.vector.Vector
+        Direction of application of force.
+    magnitude: (optional)
+        defines the magnitude of force.
+
+    Example
+    -------
+    >>> body = Body('body')
+    >>> force = Force(body.masscenter, body.frame.z, Symbol('g'))
+    >>> body.add_force(force)
+
+    """
+    def __init__(self, point, direction, magnitude=None):
+        self.point = point
+        self.direction = direction.normalize()
+        if magnitude is None:
+            self.magnitude = Symbol("ForceMagnitude_" + point.name)
+        else:
+            self.magnitude = magnitude
+
+    def get_force_tuple(self):
+        return (self.magnitude * self.direction, self.point)

--- a/pydy/tests/test_forces.py
+++ b/pydy/tests/test_forces.py
@@ -1,0 +1,21 @@
+from sympy import Symbol
+from sympy.physics.vector import Point
+from sympy.physics.mechanics import ReferenceFrame
+
+from ..forces import Force
+
+class TestForce():
+    def setup(self):
+        self.point = Point('point')
+        self.reference_frame = ReferenceFrame('referenceframe')
+        self.point.set_vel(self.reference_frame, 0)
+        self.force = Force(self.point, self.reference_frame.z, Symbol('g'))
+
+    def test_force_init(self):
+        assert self.force.point == self.point
+        assert self.force.direction == self.direction.normalize()
+        assert self.force.magnitude == self.magnitude
+
+    def test_force_get_force_tuple(self):
+        force_tuple = self.force.get_force_tuple()
+        assert force_tuple = (self.direction.normalize() * self.magnitude, self.point)


### PR DESCRIPTION
Works on the basic principle of adding a force with a magnitude and direction to a point. Have a method to return the tuple, magnitude * direction and point. Direction is always taken as a unit vector.

**Parameters**
1. point: sympy.physics.vector.Point - Point of application of force.
2. direction: sympy.physics.vector.Vector - Direction of application of force.
3. magnitude: (optional) - defines the magnitude of force.

**Example**
```
>>> body = Body('body')
>>> force = Force(body.masscenter, body.frame.z, Symbol('g'))
>>> body.add_force(force)
```

- [ ] There are no merge conflicts.
- [ ] If there is a related issue, a reference to that issue is in the
  commit message.
- [ ] Unit tests have been added for the new feature.
- [ ] The PR passes tests both locally (run `nosetests`) and on Travis CI.
- [ ] All public methods and classes have docstrings. (We use the [numpydoc
  format](https://github.com/numpy/numpy/blob/master/doc/HOWTO_DOCUMENT.rst.txt).)
- [ ] An explanation has been added to the online documentation. (`docs`
  directory)
- [ ] The code follows PEP8 guidelines. (use a linter, e.g.
  [pylint](http://www.pylint.org), to check your code)
- [ ] The new feature is documented in the [Release
  Notes](https://github.com/pydy/pydy#release-notes).
- [ ] The code is backwards compatible. (All public methods/classes must
  follow deprecation cycles.)
- [ ] All reviewer comments have been addressed.