### PR TITLE
Making PyDy compatible with Jupyter(IPython4+)

### DIFF
--- a/examples/mass_spring_damper/mass_spring_damper.ipynb
+++ b/examples/mass_spring_damper/mass_spring_damper.ipynb
@@ -4,7 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "#Defining the Problem"
+    "#Defining the Problem#"
    ]
   },
   {
@@ -343,7 +343,6 @@
    "outputs": [
     {
      "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAB8AAAAUBAMAAACHR/vJAAAAMFBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAv3aB7AAAAD3RSTlMAEImZdt1mVO+rIkS7\nMs09G46hAAAACXBIWXMAAA7EAAAOxAGVKw4bAAAAuElEQVQYGWNggABGKA2nlj6EM8EM7r6IBSgi\n8g5MDSgCQCMEUAQwOCxPQw2hgozKDoxhDO8dWL9ABZjYGxgimf4x8MEEljMHMBTxf2JgvABVIcDh\nwLB9PUwaJLhfgMEBRcCUgUGB/zNQhj3+I8dXoGtOMrBfYP7BwHCPgef3ig1ACT0GIQaG9xN4XzMw\nxLeDzOBUS2BgYHkRA7RlfSNIAAmcBBmBBDgn7D+AxGVg63fg/1GALAJmAwDdwCsc67z00AAAAABJ\nRU5ErkJggg==\n",
       "text/latex": [
        "$$v\\mathbf{\\hat{c}_x}$$"
       ],
@@ -378,7 +377,6 @@
    "outputs": [
     {
      "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAK4AAAAVBAMAAAAtL8hrAAAAMFBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAv3aB7AAAAD3RSTlMAMmYiu80QdonvRN2Z\nVKvu110NAAAACXBIWXMAAA7EAAAOxAGVKw4bAAACq0lEQVQ4Ea1UTWgTURD+kmw2281PcxFPQqwH\nEQUDehFRox4EEVzBeLCCKypUFJKLTfC0F9uK0ggKFosYFJRSkFxSlSjmIiJFGqmoRTABC+3JbowY\nGoxxXndfNokNKbVzePPNN/O+fTvzdoG1NbUuZwvU4X+BjWy3I61ykZ0crMafG63v8vkJjvXe4sQJ\nDlblT1m7FEAs45pJuDQr04LOtsTLhVWLjBNUIZpEV9DKtKBPLfEyofzLIi9YkNB4U9QUrEBXopfn\n5swBlzMvVCO+wWnmh2L+vje4GDC4uu7n2Ad5eEdsTh48bGTqq1Ozv/WLsW+PBwEpC2cZr6JG8kC9\nBtidcyraDNwFg+O6UsjxWxIOIXIFMw3VDEYeDYwl+7A1mgbsChIKTpu6LxsqR+Cbzk3Cqxkc182r\nqG5wK9inYXtDNYP59bQMIKFOA94UahrOmBV36Xb0ZsjSfg8NQcQdyNQoZlz3NmwlNZIE6c8y/jwr\nzxxjcOokLSqOM2zTHTXzsBSRLreuECGasIsRV8Ph5+Ewu562H3ClkAcmQQ9ttqd7FUaU2dKs29CH\niEZZTwoSqyIzz2svQcjiNfAMcolfT6NCLIpVBykW2bWVqQ9Z4r/U1PsTaJhbdwDICQW8NzZxXa+O\n7hxGIFbgUfaYOcPZdbEi4aNLR//S3KZuwqbg6ENqwrBV6Cngkl9SRM2kzPOKJSwEHRXYdTg1njNK\nfCEUJbkq6I4AvSndsz9Yl4R7kQY0boowN9RDfZ/v4Yypiyfx6+wlXQV45/08ueSFALZFxbn+ONvj\nTNJ3MbqffmqLKuAOop1xXeBIu5JGfhcPhIUJ6kqWh//4BwZjY51dgdEnZ9h3+SeBgzxs5xMqzbKz\niYpZs6WM2j2g43/96+Z3nVUBoaWhbJRrYZuaRP4CFs6wduv08VgAAAAASUVORK5CYII=\n",
       "text/latex": [
        "$$(- c v + g m - k x)\\mathbf{\\hat{c}_x}$$"
       ],
@@ -415,7 +413,6 @@
    "outputs": [
     {
      "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAL8AAAASBAMAAAD4RhIFAAAAMFBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAv3aB7AAAAD3RSTlMAEM3dMol2IlTvq5m7\nZkT3Gyx5AAAACXBIWXMAAA7EAAAOxAGVKw4bAAACGUlEQVQ4EbVSz2sTQRh902Sy06ZJFiU9eDBh\na++hgogg7H/gUMWLFPdgKwTBPYkXdQ/20CJYingqUgTRg2CwUsSLufoLe+pFxAUpiJc0Yo0gLX7j\nbmZ3xDT+6nfYffPe+743szvAXxd7VuvXm1nq59hRH2jsKJNYqfZ0ML+npIVSoOGfA+H172nZ/T09\nHb8TMNGz+5cCP3mGnfLY0UjUATPT17B+90LdWz8X/tQ3hjc3MFK/POUZgnaXV7B3VUvWYThczONI\nxHQDeNP6BvnSY19CEo1i2+X9t5gsHMpUDV675SxS12hQ4t7FfA0zkbkbcN3G12wwDmsThQ1jDsRn\nD+A2bws/LWi3FSxDSOw5qOoAntqAPejhgxmwiGyHsW2INoaaJLFRZR93CeY/hbTGQJMw9BxoN8NN\nFIMfonosqgfdC49e3HFGFxynAWS3kKtBbIDORulGZc7eVuuSZ7BI3MU2clpjmwouAzKi4k9U6GC4\ngXwVGYmWT4dMVcWtBD5wzIXJazdtiif+LYrGcwg3ouIA2nspAP2fSoiHVpDYCb0jUgr7PHJmgHYP\nL+Fq0vEE7BEmUI6ZOIB18MDHlZCmYSy1HeW6j5IrW8FrXEqmKKTdvMpkIvHJNWBocjVm4gB8nDoO\nvAfqwNyJxK3QKxRWsG96RPfEcuK+89bsSK+6AcCLNP3/cDE6ShZ0RXezTtv0p3az5tYe/+P47+mH\niqcCCepKAAAAAElFTkSuQmCC\n",
       "text/latex": [
        "$$- c v + g m - k x - m \\dot{v}$$"
       ],
@@ -449,7 +446,6 @@
    "outputs": [
     {
      "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAPkAAAAyBAMAAABsTmDUAAAAMFBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAv3aB7AAAAD3RSTlMAiUSZq1TvELvdZiIy\nds1Wk1T5AAAACXBIWXMAAA7EAAAOxAGVKw4bAAAET0lEQVRYCcVYT4gbVRj/TbLJzOTvlBaKh3Vz\nEEVFmoMWetBNb4IsG0FWpUrqP6gHMcUilkITLHhQxIh/oAdLwIvWP7sHFcWDuXiUZr30tHTQggqy\nhJVQ6G7R73sz702SeUmHicx+hze/+f79Mm/ee9+XAUiMCg3JypmA7mAAk0IpVzIZNQ+VmlKTwPVr\nybHmsebfS5Ldcjx683lxNS+sJsluvuSxW1V/Eq4lyY41j7UhSZNltx1B/4H/6EiWPbPLvDkxMkqW\nHeKp7TYzsyTMvs5v/EqFmVkSZm/1ifOoYN4H9pJLpC/uF3uRFlzh5n6x528B/At8Sfi94xRgnZTk\nD776YdfHBQmkLeb1y5lxbwHZtsbje40usuqNl5XrQk9BDVjaQKuq0f+h0UVX/R64ugEMo/UKjvCu\nm5CiM6EIbs8FcCoaBpbNAIbRlT4a9bA6uxHW+Zpnp1qUIXVDQbwewDCiab/WC6vvDaukJgK74Upn\noKR5NmUt17Csec6xPu/AVu/0wzjb9YIU++NbT6UO/bi1klp8U6XzQMnJHe2ZW489sEj9anXCSLcq\nW7mtZX97JOSHesl11mDXPJ1kN9r5fwzrXbR+lW2Cimndc/juyml83r9EBdRVagVUtqwLXTv1kfIE\nnsPCifoxZBxPJ9kbTQx/tl385GB9xJth4xcaDmOpeQLIdCaMQF5ly3aw6pn/lTKge2r0zL8uklzq\npWkJmXgFqbrnJ9lPobDbbFVAv+JRtpxn94t/M1z+jYYm/mRc4HTjEmSzT0r2MQ9il5JtE6JVXGTF\nndvbH29v83am6lDsoAEcA/20cfnkG5cVt3jQsKtsIPblJnuNy8jMtxwypTswfA//2akhsqp4BHgf\nqV1zLNrcM4d54t2jOUOqM2YTNyqb3QEddyEZWXXlLlC3anjGd/LZMwOU67QmzB2k3W/HEuQG5o6B\nJ4sDXNWvOpWN3rtuvx8K0qVreK1nuCZPAYvPbu5idSO/g9wAJUfaPI+FNvaM1NAa5Ls0a1VStlwa\nAlHZaM3TYRuS0dPmwOU+cPyy9PHZcdfmHTytxRoyx3vSKK5WF5/2zZWrmxxTqtBgjxx+7CKz0X5v\nsH1C7I0JRXAr2YELgXI6+k6Y7tc70EmrqzI5ni+93OepC/zGI8ii8OnqPanKaCvsO3r3QLvUpLVz\nezFd9jG7PIaFChy9+rDctrt44quHwlFhjSVeYS5sEBrabtZAY+Pl+n/IFzOT0DFb9BbklHo1M3pe\nI3WVhaFIMqVezUswK547av/fxJR6NSt6Xpvo5ZdFltF6NW/aiPFWhxyPVIS3vl5FTBTLrdynMLsq\nYrX1KlbWqEHrTfLMeYteW6+iJorld11EvcCjvl7FyhoxKOX9gaTmSLQBmnoVMVEsN+pOWEreJVaK\nOYLkN8q9OXLEDvW/UQJPx04xR6A/8dT+1ObIEjf0MxW4olBiIPhCjnQlMVZJdIY3Gv4DK00Ctyfd\nhpkAAAAASUVORK5CYII=\n",
       "text/latex": [
        "$$\\left ( \\frac{1}{m} \\left(- c v + g m - k x\\right), \\quad v\\right )$$"
       ],
@@ -522,7 +518,6 @@
    "outputs": [
     {
      "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAQoAAAAaBAMAAAC9RA/VAAAAMFBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAv3aB7AAAAD3RSTlMAMkS7zRCZdiKJ71Rm\nq90icBAQAAAACXBIWXMAAA7EAAAOxAGVKw4bAAADd0lEQVRIDcWXy2sTURTGv6SZNJNJk+A/0GyL\n2AYKLsRHhWy6sAQplIKaCJWurCNCfVEdFHGh0BGLRegiPsDtdKkiZqUgSgsVVOpihPoANdbSYEtd\neO69827StLbQA5M559zvnvnNuYe0AbADaKp8w1ZYe0WvVWZ/RauVBrheZWuhLJCsLdp4NjZda49Z\nK8lzTL+LeZH8NlPIZaIYpGtTvZD2mFRC2EZ68ZO2cP1nulcp2BQFIkWBYFd1Itsxbcd7lxYp4hTD\ngFykoD6FpNFyA0sZjmAjvWCbuH4UiLMS9SkU1XlCXaeDJsuy/6JIltHKSmyOYsxmsN7NDS3PXJWx\nE5w6msUrlvBSyOOnpTuq9EMInV4o4xezbe+vj6htZzJiyfnsxot76Bu5cl4VHXYWbMe0HcAp0T+I\nY2Whby5hgCk8FLHvyMlKCWyCyRyK2xgt6p2q9CdDiz6TFvoP35f0xNdkV2MKp4T+BMlpoQ9X0ckq\neijiOmZvRE08Fk+yKZQqUpPGHGLLSMz7IKD8ptmR83JV0RpShOwSMWMIii70od84ZFH0VpgdxCma\nk3xcxU4/RTyL1mvSAoimJUtLUg+Tz6XJjS5mKEaEpetOp1VesktIeISwIfSxBXyhvd5ePGAxTb1K\nNzmX63mYyxXJbS3jEpR5UJcI0WfJc29ZnGLpuhT2DqcEHUOzpY+tOL2wZNIyc4YAXSTsE5nSsBvR\nLiR1dGh5SyxuhXTB0IgzjXxjCqcEvY5sUywEKfCXJhL7oKT9FM+BFdDMFDIYiBk+iilK6kr+MprX\nQeGUaJrGpEURWsIMq+iZzpOQjmMM/daD7F4UtJYljGYwBXTTO3htBqm03mEcwM11nIhTQu6SqN38\nBOlwLrCCHgp54iXQMlG2nmNThN/dNdEOjADPbllr1m0vEoM4eraP7eFV+V8Ir8Z0A7fEh9eU5fpE\niQ2ij8LdwD2bgv4TKvLE2h+8Kn6xmh4zPb7f5Xr67oxnKO/phV+FcFkk0mwiGpugCGt+pekPPRHX\nR1RE6XTWoLB2yFWa2HWYoEgElGYgdkOuL+QRKlGufi+sDcrHYcPdW98TFEcCAjMQuyHXv6F4lq6G\nFO6+tT1BUQ6IzEDshlz/ieJeuraYwn2K8MxgwokZRYLNhFLcZoqrnOkpUWzZ7xF6t9VWqf97hPQn\nVm/Ynsw/ebIFHs4MavoAAAAASUVORK5CYII=\n",
       "text/latex": [
        "$$\\left ( \\left[\\begin{matrix}- c v + g m - k x\\end{matrix}\\right], \\quad \\left[\\begin{matrix}- m \\dot{v}\\end{matrix}\\right]\\right )$$"
       ],
@@ -556,7 +551,6 @@
    "outputs": [
     {
      "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAR8AAAAyBAMAAACXPMIiAAAAMFBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAv3aB7AAAAD3RSTlMAiUSZq1TvELvdZiIy\nds1Wk1T5AAAACXBIWXMAAA7EAAAOxAGVKw4bAAAFaElEQVRYCc1ZXWhcRRT+7iZ7Z/+yudAHsZj2\nFvxBXxKhFgq1iQ8+qWQLJShUsqiFCko3WMQqNQst4lsDtuIP1YAgItQE0RdBel/El0i2GMQHQ9a/\nNwm1NQRMajxnfu6dvd6um2wT7nmYOXPmm3O+OTP37sxdgMTxgZMbf5KWKM7GRjWxw93Y8BI7NmlU\nAU5Fo3aRenzu28jQqom5b6qtFt1yj83VEjs2aVQBMk0zzBkh7QXTSqpL1SQr3CDRvAWjDPCZGTjG\n05SEyrEJiwe/Dxi1M4Ryev3FMxyTCRXPxwiVK+J97twZQuI4xwJyQ1wSIXF2NEboY2APd+4MIYxx\nLGBcspBLthQjdE737hChvCcJvSXLREJ/AYMV6t4hQtk1plKQpdrUsQyJG0So0R2hiYdxeprjtBU9\nY5mbfF1CkzJUpHflPKexiwx5Y8iPyAjtCh1gpkageV8it4lQsXIQWZ5Te9GEJnk5DihoEiFBGepy\nyQReRKbSng31akLlJunPKXQSIdAeGmdvXSxZZhV9KkK7Ugfoo/1c+rsNoXcAuaxdEOqZgtOOiurT\nAYo3ASbFkpihH4DD3NkFodwIjrGL9mICnKD3dFVBEwnlK0LaDT7m1Q1ihoSm0xT/v6fDGb8BuHXl\nhQPvP3lhWrV0KQYWAla7IIRHPtXO2lUmwN5ZTA4poMzErcYYfKzfDWKGLTdNgBlfPdbkKB2E5hvq\nsU4NIVqvpUDlOR0Z6h/B8GyqCNVTRshtwhwS07Fk7hRG1Yql5CnLV9NHaLiWpk2dnwK9rKWkZg/Z\n76GXBg7pHRWr1Jtd/BMzu0HMsKnmK89HcPPTQU8Z/XpI4Qz9jtM6X8oWlhr/oV5eY3cDo22p/jUa\nZQj11zHuKzMRKlThNCOQpWl8JkbXDSxMq/paazOxtRJZDSH66ZBnZuohQnSWyq5GIEvT+IJlYtUN\nqEiWp5PNtpUOt6EYQvTjah0/6IckY7EO0eF56FXLxKobUJEsHRCyV8MQohM8bSMplCHilqFDbSj7\nHvt6obHvRz8kNB12KcUNLIMz8JPY1RDvKVNI6Mjik4gcWXiUvcKBAGcWPr/aCE+A9MznrikQEbri\noWR/RvPebIibfrYaErLdse4GVGgpXsSyQ9gLqm0IOfXiDUSODJrryfvuuNcXXuFSvhkSGqVDvl7J\n/xIqVT4A3V0LxNhk1PZHuhtQocX18OiXdMU4otqG0HgNK5Yjg+Z6/DsqnJqzmp0NA9Ahv6R3DS+Z\n17JkQlznTd5bb0vo9XdZ/gC/8WtuA/dQFBJD6ARKa5YjGDhBhn+hQqBcp0rPmK9B1kWxfwhZe1Nn\nr4GmTEEMntAt4gZRk+ZG19waCI09y8tvLy/za4ZufX1TiBwxyMilL5qs9vMITUjeyYbZKh/7fB0F\n61FETxN5D4OzNYNXyKh0g1DnWzdwEPCUSWeIPq3khixHIZ5ysy5WitSeDxAGyE2RYdCXKFqyvioP\njYS2xaSPw8VKB4RAF+AsziEbqPGaEOWmn57k0FHknPamuO4gW1tCX0hIZis/JFFECBfxcmANueJj\nBviZbsIdbOr9EIfo+9+EHq8JiTWMziJyZHnvrWPdoe9h5/FVGEDe2/UqMaGJxcetEbgfWACO3hXi\n7U7W3YAKLc7uy0Dv7mnd1IRw99U7YTkyaKpz0/iogVOLZ3iMnvFvsv9ZWTKhW0oHGYqNNYSAs7Ge\nxKYKkFHfGehVQXKbCT2g4pZA744ORBGi/c9SltVtJqRJ7K3RL3YHogjJL/j0uXydR2wPoaOXH+qA\njt5D6gs+4Z/aPkIdsSGQzJBeMaBnhEzbk6FNEfokRD9BWpr+nkKPn4o/8OTT/i8cX4+gnEkU9QAA\nAABJRU5ErkJggg==\n",
       "text/latex": [
        "$$\\left ( \\left[\\begin{matrix}1 & 0\\\\0 & m\\end{matrix}\\right], \\quad \\left[\\begin{matrix}v\\\\- c v + g m - k x\\end{matrix}\\right]\\right )$$"
       ],
@@ -593,7 +587,6 @@
    "outputs": [
     {
      "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAL4AAAAyBAMAAAAQKHwNAAAAMFBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAv3aB7AAAAD3RSTlMA74lUMhCZdt1mqyJE\nu82xvO3QAAAACXBIWXMAAA7EAAAOxAGVKw4bAAADaUlEQVRYCe2YX0hTURzHv7t3123eTYWEgpDu\nQ1q+6JSgEMIJlvQQXiQwitQoynrIIZEhSEYP9gdsT0oP1egPBj00iIokcBlB9bI99VBEoyKCYiz/\nFKJg59xz7+5277jzDkdQHti5vz/f32fn/s7RbReblmdQrFG//BPrWncVC499rQ2oLBqdglvW+Jb9\n/c/603Ec+0OWDTEkbfZHaoA7bEBYuvb4or8XvGQJNCTt8QWsh9dvQFi69vjwzsNlyTMmbfJLhsEZ\nEZa+Tb4vjG2WPGPSJp9LCJIRYenb5OPWNUucKWmXbwLkCazxrRv0z/Rnr/V9FprV+rP7XqEE6zqN\njx3WukKzf4G/p9C1Ztd5AtQ3r1+MZ+tseYc26PI71DTzy2RdYt/6qpeUUdPM79cVBuugwc/lzupB\nl0RsM3+jrjBY2w1+Dpd8fqaHUEHMNL9BjXuH0wKjsQI+l8go+kxsjf/46gTLcD0ZCm7LaaEmKFxi\noTS/cWAnpu8/GQxOD0Uz1MQskzyHA+gcfNYfBGpIQOOnZb5Q2oR4AUmOr8BlFtL4XFz8BelDUPgd\nJcms0f2y+nlUkDwj7gRwg6RMfLdfL3BIuP2QfGVoZCGN3yxj1ukfhTgDT0pXU6u5jUyczM3zESj/\nEhh/mQ0qdkSBrot0fEGfDMiOIF6QOBkavwrORUFYAj+P0jiJC9+ofDRAzL4f1EcZDaOdvEzrp3xt\nVFEjJiNILnXJ5Plkkh5v5wJcw+BTIHdG3jxrjEwmqF+uhHPyM/ojKD8sewGJ1qTX71mErwclCbgl\nxCIyy7FZmBNmRWK2B0Dir4hlWn/m/i4APN6BD7BqtT9k5eV+OCR0R3FK9LMcmz0pYYkDL5+Di/Bz\n7i8X1gtOQjiKOnSoEZUvLOJBBFNR3AQ+ZX9bJNsxxyHm/4inpOYYeZnWn/n3xdWOA6W1oWw+3vRv\nVW5+EGjarObYhdz8WBAHBjqVGrrXjO850XbGNRRQRFeYNMesnR/gbY6sKSRWkJDKj4Ucd11hRTJm\nEmqB18xwgpzNFQwuSESM/+gsyqMlklLki+SprZd94TwSJd1FZ7X/E8RQT6YYz1PcNH4kj4Kl39OL\nyq/EEKacLE63fhWGR+kD44spTOB69llbhbcgiBbl+Yw3jO+YrF4dZAaFPp8p8vOlPwplvh/UVTgb\nAAAAAElFTkSuQmCC\n",
       "text/latex": [
        "$$\\left[\\begin{matrix}v\\\\\\frac{1}{m} \\left(- c v + g m - k x\\right)\\end{matrix}\\right]$$"
       ],
@@ -647,16 +640,7 @@
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/home/moorepants/src/pydy/pydy/system.py:102: PyDyFutureWarning: PyDy System is experimental and may change in the future.\n",
-      "  warnings.warn(msg, PyDyFutureWarning)\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "sys = System(kane)"
    ]
@@ -737,15 +721,7 @@
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      ":0: FutureWarning: IPython widgets are experimental and may change in the future.\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "from pydy.viz import *"
    ]
@@ -810,7 +786,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/home/moorepants/src/pydy/pydy/viz/camera.py:73: PyDyUserWarning: Rotation of Perspective Camera does not work properly in the visualiser.\n",
+      "/home/tarun/miniconda/envs/pydy_env/pydy/pydy/pydy/viz/camera.py:73: PyDyUserWarning: Rotation of Perspective Camera does not work properly in the visualiser.\n",
       "  warnings.warn(msg, PyDyUserWarning)\n"
      ]
     }
@@ -875,6 +851,15 @@
    "source": [
     "scene.display_ipython()"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {

--- a/pydy/viz/scene.py
+++ b/pydy/viz/scene.py
@@ -40,10 +40,18 @@ try:
                'not be available')
         warnings.warn(msg.format(IPython.__version__), PyDyImportWarning)
         ipython_less_than_3 = True
-    else:
+    elif parse_version(IPython.__version__) == parse_version('3.0'):
         ipython_less_than_3 = False
         from IPython.html import widgets
         from IPython.display import display, Javascript
+    else:
+    	# Everything above IPython3 is Jupyter now.
+    	# All the ever-changing IPython code can be updated here.
+    	ipython_less_than_3 = False
+    	import ipywidgets as widgets
+    	from IPython.display import display, Javascript
+
+
 except ImportError:
     IPython = None
 

--- a/pydy/viz/scene.py
+++ b/pydy/viz/scene.py
@@ -45,11 +45,11 @@ try:
         from IPython.html import widgets
         from IPython.display import display, Javascript
     else:
-    	# Everything above IPython3 is Jupyter now.
-    	# All the ever-changing IPython code can be updated here.
-    	ipython_less_than_3 = False
-    	import ipywidgets as widgets
-    	from IPython.display import display, Javascript
+        # Everything above IPython3 is Jupyter now.
+        # All the ever-changing IPython code can be updated here.
+        ipython_less_than_3 = False
+        import ipywidgets as widgets
+        from IPython.display import display, Javascript
 
 
 except ImportError:


### PR DESCRIPTION
This PR is to update the code to be compatible with the upcoming versions of IPython-Jupyter.
Below is the checklist on the things broken/need to modify on upgrading Ipython to Jupyter.
@moorepants Please feel free to add more as per your observations.

  - [ ] Fix Re-run Simulation Button (Takes up the whole width of the canvas)
  - [ ] Markdown does not seem to be working on Jupyter. 