### PR TITLE
Fix dependency minimum versions in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,11 +20,11 @@ if sys.version_info >= (3, 0):
     CYTHON_MIN_VER = '0.20.1'
     THEANO_MIN_VER = '0.7.0'
 else:
-    NUMPY_MIN_VER = '1.7'
-    SCIPY_MIN_VER = '0.11'
+    NUMPY_MIN_VER = '1.9'
+    SCIPY_MIN_VER = '0.14'
     SYMPY_MIN_VER = '0.7.4.1'
     CYTHON_MIN_VER = '0.17'
-    THEANO_MIN_VER = '0.6.0'
+    THEANO_MIN_VER = '0.7.0'
 
 setup(
     name='pydy',


### PR DESCRIPTION
This change is due to the following commit:
https://github.com/pydy/pydy/commit/9e414bba90fc52a366b7c37977d2247ad34cce51