### PR TITLE
Create text widgets for System time parameters

### DIFF
--- a/pydy/viz/scene.py
+++ b/pydy/viz/scene.py
@@ -416,14 +416,17 @@ class Scene(object):
             times = self.system.times
 
         if times is None:
+            tf = (num_time_steps - 1)/self.frames_per_second
             self._scene_info["timeDelta"] = 1.0 / self.frames_per_second
             self._scene_info["startTime"] = 0.0
+            self._scene_info["endTime"] = tf
         else:
             # Assume that times is evenly spaced and monotonic.
             # TODO: Interpolate if times are not evenly spaced.
             total_time = times[-1] - times[0]
             self._scene_info["timeDelta"] = total_time / (num_time_steps - 1)
             self._scene_info["startTime"] = times[0]
+            self._scene_info["endTime"] = times[-1]
 
         self._scene_info["fps"] = self.frames_per_second
         self._scene_info["speedup"] = (self.frames_per_second *

--- a/pydy/viz/scene.py
+++ b/pydy/viz/scene.py
@@ -417,20 +417,20 @@ class Scene(object):
 
         if times is None:
             tf = (num_time_steps - 1)/self.frames_per_second
-            self._scene_info["timeDelta"] = 1.0 / self.frames_per_second
+            self._scene_info["timeStep"] = 1.0 / self.frames_per_second
             self._scene_info["startTime"] = 0.0
             self._scene_info["endTime"] = tf
         else:
             # Assume that times is evenly spaced and monotonic.
             # TODO: Interpolate if times are not evenly spaced.
             total_time = times[-1] - times[0]
-            self._scene_info["timeDelta"] = total_time / (num_time_steps - 1)
+            self._scene_info["timeStep"] = total_time / (num_time_steps - 1)
             self._scene_info["startTime"] = times[0]
             self._scene_info["endTime"] = times[-1]
 
         self._scene_info["fps"] = self.frames_per_second
         self._scene_info["speedup"] = (self.frames_per_second *
-                                       self._scene_info["timeDelta"])
+                                       self._scene_info["timeStep"])
         self._scene_info["timeSteps"] = num_time_steps
         self._scene_info["constant_map"] = constant_map_for_json
 
@@ -652,8 +652,12 @@ class Scene(object):
         original_sim_file = self._simulation_json_file
         original_constants = self.system.constants.copy()
         try:
-            self.system.constants = {s: w.value for s, w in
-                                     self._constants_text_widgets.items()}
+            d = {s: w.value for s, w in self._constants_text_widgets.items()}
+            t0 = d.pop('start time')
+            tf = d.pop('end time')
+            dt = d.pop('time step')
+            self.system.constants = d
+            self.system.times = np.arange(t0, tf, dt)
             pydy_dir = os.path.join(os.getcwd(), self.pydy_directory)
             self._generate_json(directory=pydy_dir)
         except:
@@ -690,6 +694,15 @@ class Scene(object):
                                             description=desc)
 
             self._constants_text_widgets[sym] = text_widget
+
+        # add in time parameters
+        for k in ['start time', 'time step', 'end time']:
+            # TODO: don't set time values both here and in _scene_info
+            k1, k2 = k.split()
+            key = '{}{}'.format(k1, k2.capitalize())
+            w = widgets.FloatText(value=self._scene_info[key],
+                                  description=k)
+            self._constants_text_widgets[k] = w
 
     def _initialize_rerun_button(self):
         """Construct a button for controlling rerunning the simulations."""

--- a/pydy/viz/static/js/dyviz/dv.js
+++ b/pydy/viz/static/js/dyviz/dv.js
@@ -151,7 +151,7 @@ DynamicsVisualizer = Class.create({
         var div = jQuery("#simulation-params").fadeOut();
         div.html(" "); // clear html first
 
-        for(var i in constants){
+        for (var i in constants) {
             div.append('<span class="input-group-addon">' + i + '</span>');
             div.append(jQuery('<input />',{ type:'text', id: i, class: 'form-control', value: constants[i]}));
         }

--- a/pydy/viz/static/js/dyviz/parser.js
+++ b/pydy/viz/static/js/dyviz/parser.js
@@ -63,31 +63,10 @@ DynamicsVisualizer.Parser = Object.extend(DynamicsVisualizer, {
                 self.simData = jQuery.parseJSON(transport.responseText);
             },
             onComplete: function(){
-                self.createTimeArray();
                 self.Scene.setAnimationTime(self.model.startTime);
             },
             onFailure: function() { alert('[PyDy ALERT]: Simulation File not loaded!'); },
             on404: function(){ alert("[PyDy ALERT]: Simulation File Not Found! Error:404"); }
         });
     },
-
-    createTimeArray: function(){
-        /**
-          * Creates a time array from
-          * the information inferred from
-          * simulation data.
-        **/
-        var self = this;
-        var timeSteps = self.model.timeSteps;
-        var timeDelta = self.model.timeDelta;
-        var time = self.model.startTime;
-        self._timeArray = [];
-
-        for(var i = 0; i < timeSteps; i++){
-            self._timeArray.push(time);
-            time += timeDelta;
-        }
-        self._finalTime = self._timeArray.slice(-1)[0];
-        console.log("[PyDy INFO]: Created Time Array");
-    }
 });

--- a/pydy/viz/static/js/dyviz/scene.js
+++ b/pydy/viz/static/js/dyviz/scene.js
@@ -380,7 +380,7 @@ DynamicsVisualizer.Scene = Object.extend(DynamicsVisualizer, {
 
         var t0 = self.model.startTime;
         var tf = self.model.endTime;
-        var dt = self.model.timeDelta;
+        var dt = self.model.timeStep;
 
         if(!self.animationPaused){
           self.currentTime = t0;
@@ -412,7 +412,7 @@ DynamicsVisualizer.Scene = Object.extend(DynamicsVisualizer, {
         var tf = self.model.endTime;
         var percent = (100*(currentTime - t0)/(tf - t0)).toFixed(3);
 
-        var time_index = Math.round((currentTime - t0)/self.model.timeDelta);
+        var time_index = Math.round((currentTime - t0)/self.model.timeStep);
         var _children = self._scene.children;
         for(var i=0;i<_children.length;i++){
           if(!(_children[i] instanceof (THREE.OrthoGraphicCamera || THREE.PerspectiveCamera))){

--- a/pydy/viz/static/js/dyviz/scene.js
+++ b/pydy/viz/static/js/dyviz/scene.js
@@ -378,25 +378,27 @@ DynamicsVisualizer.Scene = Object.extend(DynamicsVisualizer, {
         jQuery("#pause-animation").prop('disabled', false);
         jQuery("#stop-animation").prop('disabled', false);
 
-        var startTime = self.model.startTime;
+        var t0 = self.model.startTime;
+        var tf = self.model.endTime;
+        var dt = self.model.timeDelta;
+
         if(!self.animationPaused){
-          self.currentTime = startTime;
+          self.currentTime = t0;
         }
 
         self.animationPaused = false;
-        var timeDelta = self.model.timeDelta;
 
         self.animationID = window.setInterval(function(){
                 self.setAnimationTime(self.currentTime);
-                self.currentTime += timeDelta;
-                if(self.currentTime >= self._finalTime){
-                  self.currentTime = startTime;
+                self.currentTime += dt;
+                if(self.currentTime >= tf){
+                  self.currentTime = t0;
                   if(!jQuery("#play-looped").is(":checked")){
                     self.stopAnimation();
                   }
                 }
             },
-        timeDelta*1000);
+        dt*1000);
     },
 
     setAnimationTime: function(currentTime){
@@ -407,9 +409,10 @@ DynamicsVisualizer.Scene = Object.extend(DynamicsVisualizer, {
         **/
         var self = this;
         var t0 = self.model.startTime;
-        var percent = (100*(currentTime - t0)/(self._finalTime - t0)).toFixed(3);
+        var tf = self.model.endTime;
+        var percent = (100*(currentTime - t0)/(tf - t0)).toFixed(3);
 
-        var time_index = self._timeArray.indexOf(currentTime);
+        var time_index = Math.round((currentTime - t0)/self.model.timeDelta);
         var _children = self._scene.children;
         for(var i=0;i<_children.length;i++){
           if(!(_children[i] instanceof (THREE.OrthoGraphicCamera || THREE.PerspectiveCamera))){


### PR DESCRIPTION
This pull request resolves https://github.com/pydy/pydy/issues/206.

Maybe we should move the time parameter widgets so they are horizontally stacked instead of vertically? I don't know how to do that so someone else can, ideally in another pull request.

We also need to have some sort of widget or slider for fps/speedup since it's kind of dumb to tie the simulation time step to the speed of the visualization.