### PR TITLE
Fix LaTeX output in mass spring damper example

### DIFF
--- a/examples/mass_spring_damper/mass_spring_damper.ipynb
+++ b/examples/mass_spring_damper/mass_spring_damper.ipynb
@@ -233,7 +233,7 @@
    "outputs": [],
    "source": [
     "from sympy.physics.vector import init_vprinting\n",
-    "init_vprinting()"
+    "init_vprinting(use_latex='mathjax')"
    ]
   },
   {


### PR DESCRIPTION
This commit resolves https://github.com/pydy/pydy/issues/286.