### PR TITLE
Don't use stdout=PIPE when generating Python modules

### DIFF
--- a/pydy/codegen/cython_code.py
+++ b/pydy/codegen/cython_code.py
@@ -213,8 +213,15 @@ setup(name="{prefix}",
             self.write()
             cmd = [sys.executable, self.prefix + '_setup.py', 'build_ext',
                    '--inplace']
-            subprocess.call(cmd, stderr=subprocess.STDOUT,
-                            stdout=subprocess.PIPE)
+            try:
+                DEVNULL = subprocess.DEVNULL
+            except AttributeError:
+                DEVNULL = open(os.devnull, 'wb')
+            subprocess.check_call(cmd, stdout=DEVNULL, stderr=subprocess.STDOUT)
+            try:
+                DEVNULL.close()
+            except Exception:
+                pass
             cython_module = importlib.import_module(self.prefix)
         except:
             raise Exception('Failed to compile and import Cython module.')


### PR DESCRIPTION
When generating Python modules, use of stdout=PIPE or stderr=PIPE in
subprocess.call() can generate enough output that the OS pipe buffer
blocks, resulting in a compilation failure of generated code. For more
information, see Python documentation here:
https://docs.python.org/3/library/subprocess.html#subprocess.call

This commit resolves https://github.com/pydy/pydy/issues/290.