### PR TITLE
Fix codegen line break

### DIFF
--- a/pydy/codegen/tests/test_c_code.py
+++ b/pydy/codegen/tests/test_c_code.py
@@ -191,11 +191,11 @@ input_3[6] : [f0(t), f1(t), f2(t), f3(t), f4(t), f5(t)]\
     double pydy_5 = input_3[3];
     double pydy_6 = input_3[4];
     double pydy_7 = input_3[5];
-    double pydy_8 = input_0[6]*input_0[15];
-    double pydy_9 = input_0[6]*input_0[16];
-    double pydy_10 = input_0[6]*input_0[17];
-    double pydy_11 = input_0[6]*input_0[18];
-    double pydy_12 = input_0[6]*input_0[14] + pydy_10 + pydy_11 + pydy_4 +
+    double pydy_8 = input_0[6] * input_0[15];
+    double pydy_9 = input_0[6] * input_0[16];
+    double pydy_10 = input_0[6] * input_0[17];
+    double pydy_11 = input_0[6] * input_0[18];
+    double pydy_12 = input_0[6] * input_0[14] + pydy_10 + pydy_11 + pydy_4 +
     pydy_5 + pydy_6 + pydy_7 + pydy_8 + pydy_9 + input_3[1];\
 """
 
@@ -239,17 +239,17 @@ input_3[6] : [f0(t), f1(t), f2(t), f3(t), f4(t), f5(t)]\
     output_0[34] = input_0[18];
     output_0[35] = input_0[18];
 
-    output_1[0] = -input_0[0]*input_2[0] + input_0[6]*input_0[13] -
-    input_0[7]*input_1[0] + pydy_12 + input_3[0];
-    output_1[1] = -input_0[1]*input_2[1] - input_0[8]*input_1[1] + pydy_12;
-    output_1[2] = -input_0[2]*input_2[2] - input_0[9]*input_1[2] + pydy_10 +
-    pydy_11 + pydy_4 + pydy_5 + pydy_6 + pydy_7 + pydy_8 + pydy_9;
-    output_1[3] = -input_0[3]*input_2[3] - input_0[10]*input_1[3] + pydy_10 +
-    pydy_11 + pydy_5 + pydy_6 + pydy_7 + pydy_9;
-    output_1[4] = -input_0[4]*input_2[4] - input_0[11]*input_1[4] + pydy_10 +
-    pydy_11 + pydy_6 + pydy_7;
-    output_1[5] = -input_0[5]*input_2[5] - input_0[12]*input_1[5] + pydy_11 +
-    pydy_7;\
+    output_1[0] = -input_0[0] * input_2[0] + input_0[6] * input_0[13] -
+    input_0[7] * input_1[0] + pydy_12 + input_3[0];
+    output_1[1] = -input_0[1] * input_2[1] - input_0[8] * input_1[1] + pydy_12;
+    output_1[2] = -input_0[2] * input_2[2] - input_0[9] * input_1[2] + pydy_10
+    + pydy_11 + pydy_4 + pydy_5 + pydy_6 + pydy_7 + pydy_8 + pydy_9;
+    output_1[3] = -input_0[3] * input_2[3] - input_0[10] * input_1[3] + pydy_10
+    + pydy_11 + pydy_5 + pydy_6 + pydy_7 + pydy_9;
+    output_1[4] = -input_0[4] * input_2[4] - input_0[11] * input_1[4] + pydy_10
+    + pydy_11 + pydy_6 + pydy_7;
+    output_1[5] = -input_0[5] * input_2[5] - input_0[12] * input_1[5] + pydy_11
+    + pydy_7;\
 """
 
         self.generator._generate_cse()
@@ -332,25 +332,27 @@ input_3[6] : [f0(t), f1(t), f2(t), f3(t), f4(t), f5(t)]\
     output_0[34] = input_0[18];
     output_0[35] = input_0[18];
 
-    output_1[0] = -input_0[0]*input_2[0] + input_0[6]*input_0[13] +
-    input_0[6]*input_0[14] + input_0[6]*input_0[15] + input_0[6]*input_0[16] +
-    input_0[6]*input_0[17] + input_0[6]*input_0[18] - input_0[7]*input_1[0] +
-    input_3[0] + input_3[1] + input_3[2] + input_3[3] + input_3[4] +
+    output_1[0] = -input_0[0] * input_2[0] + input_0[6] * input_0[13] +
+    input_0[6] * input_0[14] + input_0[6] * input_0[15] + input_0[6] *
+    input_0[16] + input_0[6] * input_0[17] + input_0[6] * input_0[18] -
+    input_0[7] * input_1[0] + input_3[0] + input_3[1] + input_3[2] + input_3[3]
+    + input_3[4] + input_3[5];
+    output_1[1] = -input_0[1] * input_2[1] + input_0[6] * input_0[14] +
+    input_0[6] * input_0[15] + input_0[6] * input_0[16] + input_0[6] *
+    input_0[17] + input_0[6] * input_0[18] - input_0[8] * input_1[1] +
+    input_3[1] + input_3[2] + input_3[3] + input_3[4] + input_3[5];
+    output_1[2] = -input_0[2] * input_2[2] + input_0[6] * input_0[15] +
+    input_0[6] * input_0[16] + input_0[6] * input_0[17] + input_0[6] *
+    input_0[18] - input_0[9] * input_1[2] + input_3[2] + input_3[3] +
+    input_3[4] + input_3[5];
+    output_1[3] = -input_0[3] * input_2[3] + input_0[6] * input_0[16] +
+    input_0[6] * input_0[17] + input_0[6] * input_0[18] - input_0[10] *
+    input_1[3] + input_3[3] + input_3[4] + input_3[5];
+    output_1[4] = -input_0[4] * input_2[4] + input_0[6] * input_0[17] +
+    input_0[6] * input_0[18] - input_0[11] * input_1[4] + input_3[4] +
     input_3[5];
-    output_1[1] = -input_0[1]*input_2[1] + input_0[6]*input_0[14] +
-    input_0[6]*input_0[15] + input_0[6]*input_0[16] + input_0[6]*input_0[17] +
-    input_0[6]*input_0[18] - input_0[8]*input_1[1] + input_3[1] + input_3[2] +
-    input_3[3] + input_3[4] + input_3[5];
-    output_1[2] = -input_0[2]*input_2[2] + input_0[6]*input_0[15] +
-    input_0[6]*input_0[16] + input_0[6]*input_0[17] + input_0[6]*input_0[18] -
-    input_0[9]*input_1[2] + input_3[2] + input_3[3] + input_3[4] + input_3[5];
-    output_1[3] = -input_0[3]*input_2[3] + input_0[6]*input_0[16] +
-    input_0[6]*input_0[17] + input_0[6]*input_0[18] - input_0[10]*input_1[3] +
-    input_3[3] + input_3[4] + input_3[5];
-    output_1[4] = -input_0[4]*input_2[4] + input_0[6]*input_0[17] +
-    input_0[6]*input_0[18] - input_0[11]*input_1[4] + input_3[4] + input_3[5];
-    output_1[5] = -input_0[5]*input_2[5] + input_0[6]*input_0[18] -
-    input_0[12]*input_1[5] + input_3[5];\
+    output_1[5] = -input_0[5] * input_2[5] + input_0[6] * input_0[18] -
+    input_0[12] * input_1[5] + input_3[5];\
 """
 
         self.generator._ignore_cse()
@@ -403,11 +405,11 @@ void evaluate(
     double pydy_5 = input_3[3];
     double pydy_6 = input_3[4];
     double pydy_7 = input_3[5];
-    double pydy_8 = input_0[6]*input_0[15];
-    double pydy_9 = input_0[6]*input_0[16];
-    double pydy_10 = input_0[6]*input_0[17];
-    double pydy_11 = input_0[6]*input_0[18];
-    double pydy_12 = input_0[6]*input_0[14] + pydy_10 + pydy_11 + pydy_4 +
+    double pydy_8 = input_0[6] * input_0[15];
+    double pydy_9 = input_0[6] * input_0[16];
+    double pydy_10 = input_0[6] * input_0[17];
+    double pydy_11 = input_0[6] * input_0[18];
+    double pydy_12 = input_0[6] * input_0[14] + pydy_10 + pydy_11 + pydy_4 +
     pydy_5 + pydy_6 + pydy_7 + pydy_8 + pydy_9 + input_3[1];
 
     output_0[0] = input_0[13] + pydy_3;
@@ -447,17 +449,17 @@ void evaluate(
     output_0[34] = input_0[18];
     output_0[35] = input_0[18];
 
-    output_1[0] = -input_0[0]*input_2[0] + input_0[6]*input_0[13] -
-    input_0[7]*input_1[0] + pydy_12 + input_3[0];
-    output_1[1] = -input_0[1]*input_2[1] - input_0[8]*input_1[1] + pydy_12;
-    output_1[2] = -input_0[2]*input_2[2] - input_0[9]*input_1[2] + pydy_10 +
-    pydy_11 + pydy_4 + pydy_5 + pydy_6 + pydy_7 + pydy_8 + pydy_9;
-    output_1[3] = -input_0[3]*input_2[3] - input_0[10]*input_1[3] + pydy_10 +
-    pydy_11 + pydy_5 + pydy_6 + pydy_7 + pydy_9;
-    output_1[4] = -input_0[4]*input_2[4] - input_0[11]*input_1[4] + pydy_10 +
-    pydy_11 + pydy_6 + pydy_7;
-    output_1[5] = -input_0[5]*input_2[5] - input_0[12]*input_1[5] + pydy_11 +
-    pydy_7;
+    output_1[0] = -input_0[0] * input_2[0] + input_0[6] * input_0[13] -
+    input_0[7] * input_1[0] + pydy_12 + input_3[0];
+    output_1[1] = -input_0[1] * input_2[1] - input_0[8] * input_1[1] + pydy_12;
+    output_1[2] = -input_0[2] * input_2[2] - input_0[9] * input_1[2] + pydy_10
+    + pydy_11 + pydy_4 + pydy_5 + pydy_6 + pydy_7 + pydy_8 + pydy_9;
+    output_1[3] = -input_0[3] * input_2[3] - input_0[10] * input_1[3] + pydy_10
+    + pydy_11 + pydy_5 + pydy_6 + pydy_7 + pydy_9;
+    output_1[4] = -input_0[4] * input_2[4] - input_0[11] * input_1[4] + pydy_10
+    + pydy_11 + pydy_6 + pydy_7;
+    output_1[5] = -input_0[5] * input_2[5] - input_0[12] * input_1[5] + pydy_11
+    + pydy_7;
 
 }\
 """

--- a/pydy/tests/test_utils.py
+++ b/pydy/tests/test_utils.py
@@ -4,7 +4,11 @@ from pkg_resources import parse_version
 from setuptools import __version__ as SETUPTOOLS_VERSION
 from nose.tools import assert_raises
 
+from sympy import cos, sin, tan, sqrt, Matrix
+from sympy.physics.mechanics import dynamicsymbols
+
 from ..utils import sympy_equal_to_or_newer_than
+from ..codegen.cython_code import CythonMatrixGenerator
 
 
 def test_sympy_equal_to_or_newer_than():
@@ -18,3 +22,17 @@ def test_sympy_equal_to_or_newer_than():
     if parse_version(SETUPTOOLS_VERSION) >= parse_version('8.0'):
         with assert_raises(ValueError):
             sympy_equal_to_or_newer_than('0.7.7', '0.7.6-git')
+
+def test_codegen_linewrap():
+
+    # Generated can result in long expressions with no obvious place to insert a
+    # newline. Refer to https://github.com/pydy/pydy/issues/263.
+    x, y, z = dynamicsymbols('x y z')
+    expr = (x*y*z*cos(x)*sin(x)*tan(x)*sqrt(x)*cos(y)*sin(y)*tan(y)*
+            sqrt(y)*cos(z)*sin(z)*tan(z)*sqrt(z)*cos(x*y)*sin(x*y)*tan(x*y)*
+            sqrt(x*y)* cos(y*z)*sin(y*z)*tan(y*z)*sqrt(y*z)*cos(z*x)*
+            sin(z*x)*tan(z*x)*sqrt(z*x)*3)/8
+    mat_expr = Matrix([expr])
+
+    q = [x, y, z]
+    gen = CythonMatrixGenerator([q], [mat_expr])

--- a/pydy/utils.py
+++ b/pydy/utils.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 
+import re
 import textwrap
 
 from pkg_resources import parse_version
@@ -38,9 +39,15 @@ def wrap_and_indent(lines, indentation=4, width=79):
     # TODO : This will indent any lines that only contain a new line. Which
     # may not be preferable.
     new_lines = []
+
+    # add whitespace before and after [*/] binary operands between
+    # subexpressions and input/output
+    pattern = re.compile('(\w\])([*/])(\w)')
     for line in lines:
         if line != '\n':
-            wrapped = textwrap.wrap(line, width=width-indentation)
+            line = pattern.sub(lambda m: ' '.join(m.groups()), line)
+            wrapped = textwrap.wrap(line, width=width-indentation,
+                                    break_long_words=False)
         else:
             wrapped = [line]
         new_lines += wrapped


### PR DESCRIPTION
Some generated expressions, particularly those that contain only '\*' and
'/' operands, have no whitespace. In this case, the textwrap module may
break the line in the middle of a symbol or mathematical expression if
the line is long, resulting in code that cannot compile. This commit
adds whitespace before and after the '\*', '/' operands so that textwrap
will have more options for inserting line breaks. The textwrap option
'break_long_words' is also set to True, allowing long lines in the event
that no whitespace is present.

A test has been added that reproduces the bug.

This pull request resolves #263.

This pull request depends on https://github.com/pydy/pydy/pull/291. Please merge that request first.