### PR TITLE
Changed Travis miniconda directory to miniconda2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,7 @@ before_script:
   - pip freeze
 script:
   # Run Python and Javascript tests.
-  - nosetests -v --with-coverage --cover-package=pydy
+  - THEANO_FLAGS='gcc.cxxflags="-march=core2"' nosetests -v --with-coverage --cover-package=pydy
   # JS tests
   - cd pydy/viz/static/js/tests && phantomjs run-jasmine.js SpecRunner.html
   - cd -  # It should not be combined with above command

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ before_install:
   - wget https://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O miniconda.sh
   - chmod +x miniconda.sh
   - ./miniconda.sh -b
-  - export PATH=/home/travis/miniconda/bin:$PATH
+  - export PATH=/home/travis/miniconda2/bin:$PATH
   - conda config --set always_yes yes --set changeps1 no
   - conda update -q conda
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,8 +12,8 @@ before_install:
   - sudo apt-get update
   - wget https://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O miniconda.sh
   - chmod +x miniconda.sh
-  - ./miniconda.sh -b
-  - export PATH=/home/travis/miniconda2/bin:$PATH
+  - ./miniconda.sh -b -p $HOME/miniconda
+  - export PATH=/home/travis/miniconda/bin:$PATH
   - conda config --set always_yes yes --set changeps1 no
   - conda update -q conda
 install:


### PR DESCRIPTION
Seems that conda made a backwards incompatible change to their installer,
breaking scripts that rely on the location of miniconda. See:

https://github.com/conda/conda/issues/1928