### PR TITLE
Set minimum dependency versions to match Ubuntu Trusty 14.04 LTS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ before_install:
   - ./miniconda.sh -b
   - export PATH=/home/travis/miniconda/bin:$PATH
   - conda config --set always_yes yes --set changeps1 no
+  - conda config --add channels pydy
   - conda update -q conda
 install:
   - sudo apt-get install phantomjs

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ install:
   - conda create -q -n test-env python=$TRAVIS_PYTHON_VERSION pip coverage nose sphinx numpydoc flake8
   - source activate test-env
   - if [[ $DEP_VERSIONS == "oldest" ]]; then
-      conda install numpy=1.8.1 scipy=0.13.3 sympy=0.7.4.1 cython=0.20.1 theano=0.7.0;
+      conda install numpy=1.8 scipy=0.13 sympy=0.7.4 cython=0.20 theano=0.7;
     elif [[ $DEP_VERSIONS == "latest" ]]; then
       conda install numpy scipy sympy cython theano;
     elif [[ $DEP_VERSIONS == "master" ]]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,11 +21,7 @@ install:
   - conda create -q -n test-env python=$TRAVIS_PYTHON_VERSION pip coverage nose sphinx numpydoc flake8
   - source activate test-env
   - if [[ $DEP_VERSIONS == "oldest" ]]; then
-      if [[ $TRAVIS_PYTHON_VERSION == 2.7 ]]; then
-        conda install numpy=1.9 scipy=0.14 sympy=0.7.4 cython=0.17 theano=0.7;
-      else
-        conda install numpy=1.9 scipy=0.14 sympy=0.7.5 cython=0.20 theano=0.7;
-      fi
+      conda install numpy=1.8.1 scipy=0.13.3 sympy=0.7.4.1 cython=0.20.1 theano=0.7.0;
     elif [[ $DEP_VERSIONS == "latest" ]]; then
       conda install numpy scipy sympy cython theano;
     elif [[ $DEP_VERSIONS == "master" ]]; then

--- a/README.rst
+++ b/README.rst
@@ -69,7 +69,7 @@ PyDy has hard dependencies on the following software\ [#]_:
 
 PyDy has optional dependencies on these packages:
 
-- IPython_ >= 0.3.0
+- IPython_ >= 3.0.0
 - Theano_ >= 0.7.0
 - Cython_ >= 0.20.1
 

--- a/README.rst
+++ b/README.rst
@@ -59,19 +59,19 @@ PyDy has hard dependencies on the following software\ [#]_:
 
 - Python >= 2.7, >= 3.3
 - setuptools\ [#]_
-- NumPy_ >= 1.9
-- SciPy_ >= 0.14
-- SymPy_ >= 0.7.4 (>= 0.7.5 with Python >= 3.3)
+- NumPy_ >= 1.8.1
+- SciPy_ >= 0.13.3
+- SymPy_ >= 0.7.4.1
 
-.. [#] We only test PyDy with these minimum dependencies. Previous versions may
-   work.
+.. [#] We only test PyDy with these minimum dependencies; these module versions
+    are provided in the Ubuntu 14.04 packages. Previous versions may work.
 .. [#] setuptools >= 8.0 is required if development versions of SymPy are used.
 
 PyDy has optional dependencies on these packages:
 
 - IPython_ >= 0.3.0
-- Theano_ >= 0.7
-- Cython_ >= 0.17 (>= 0.20 with Python >= 3.3)
+- Theano_ >= 0.7.0
+- Cython_ >= 0.20.1
 
 .. _Theano: http://deeplearning.net/software/theano/
 .. _Cython: http://cython.org/

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ setup(
                     'codegen': ['Cython>=0.20.1',
                                 'Theano>=0.7.0'],
                     'examples': ['matplotlib>=0.99',
-                                 'ipython[notebook]>=0.3.0'],
+                                 'ipython[notebook]>=3.0.0'],
                     },
     tests_require=['nose>=1.3.0'],
     test_suite='nose.collector',

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 
 import os
-import sys
 
 from setuptools import setup, find_packages
 
@@ -12,19 +11,6 @@ exec(open('pydy/version.py').read())
 # https://github.com/statsmodels/statsmodels/issues/1073, so the following
 # line is added.
 os.environ["MPLCONFIGDIR"] = "."
-
-if sys.version_info >= (3, 0):
-    NUMPY_MIN_VER = '1.9'
-    SCIPY_MIN_VER = '0.14.0'
-    SYMPY_MIN_VER = '0.7.5'
-    CYTHON_MIN_VER = '0.20.1'
-    THEANO_MIN_VER = '0.7.0'
-else:
-    NUMPY_MIN_VER = '1.9'
-    SCIPY_MIN_VER = '0.14'
-    SYMPY_MIN_VER = '0.7.4.1'
-    CYTHON_MIN_VER = '0.17'
-    THEANO_MIN_VER = '0.7.0'
 
 setup(
     name='pydy',
@@ -37,13 +23,13 @@ setup(
     keywords="multibody dynamics",
     license='LICENSE.txt',
     packages=find_packages(),
-    install_requires=['numpy>={}'.format(NUMPY_MIN_VER),
-                      'scipy>={}'.format(SCIPY_MIN_VER),
-                      'sympy>={}'.format(SYMPY_MIN_VER),
+    install_requires=['numpy>=1.8.1',
+                      'scipy>=0.13.3',
+                      'sympy>=0.7.4.1',
                       ],
     extras_require={'doc': ['sphinx', 'numpydoc'],
-                    'codegen': ['Cython>={}'.format(CYTHON_MIN_VER),
-                                'Theano>={}'.format(THEANO_MIN_VER)],
+                    'codegen': ['Cython>=0.20.1',
+                                'Theano>=0.7.0'],
                     'examples': ['matplotlib>=0.99',
                                  'ipython[notebook]>=0.3.0'],
                     },


### PR DESCRIPTION
This is being used in place of PR #282.