### PR TITLE
Avoid the IPython widget deprecation warning if possible.

### DIFF
--- a/pydy/viz/scene.py
+++ b/pydy/viz/scene.py
@@ -42,7 +42,12 @@ try:
         ipython_less_than_3 = True
     else:
         ipython_less_than_3 = False
-        from IPython.html import widgets
+        # If IPython >= 4.0 use ipywidgets if installed to avoid the
+        # deprecation warning.
+        try:
+            import ipywidgets as widgets
+        except ImportError:
+            from IPython.html import widgets
         from IPython.display import display, Javascript
 except ImportError:
     IPython = None


### PR DESCRIPTION
Partially addresses #261.

- [ ] There are no merge conflicts.
- [ ] If there is a related issue, a reference to that issue is in the
  commit message.
- [x] Unit tests have been added for the bug. (Please reference the issue #
  in the unit test.)
- [ ] The tests pass both locally (run `nosetests`) and on Travis CI.
- [x] The code follows PEP8 guidelines. (use a linter, e.g.
  [pylint](http://www.pylint.org), to check your code)
- [x] The bug fix is documented in the [Release
  Notes](https://github.com/pydy/pydy#release-notes).
- [x] The code is backwards compatible. (All public methods/classes must
  follow deprecation cycles.)
- [ ] All reviewer comments have been addressed.