### PR TITLE
Adds in more type checks for System.times.

### DIFF
--- a/pydy/system.py
+++ b/pydy/system.py
@@ -53,6 +53,7 @@ you must call ``generate_ode_function`` on your own::
 import warnings
 from itertools import repeat
 
+import numpy as np
 import sympy as sm
 from sympy.physics.mechanics import dynamicsymbols
 from scipy.integrate import odeint
@@ -346,11 +347,11 @@ class System(object):
 
     @times.setter
     def times(self, new_times):
-        self._check_times(new_times)
-        self._times = new_times
+        self._times = np.asarray(new_times)
+        self._check_times(self._times)
 
     def _check_times(self, times):
-        if len(times) == 0:
+        if len(times.shape) == 0:
             raise TypeError("Times supplied should be in an array_like format.")
 
         if not all(time >= 0 for time in times):
@@ -358,6 +359,7 @@ class System(object):
 
         if any(time != sort_time for time, sort_time in zip(times, sorted(times))):
             raise ValueError("Times supplied should be in an ascending order.")
+
         return True
 
     @property

--- a/pydy/system.py
+++ b/pydy/system.py
@@ -353,12 +353,11 @@ class System(object):
         if len(times) == 0:
             raise TypeError("Times supplied should be in an array_like format.")
 
-        if not all(time>=0 for time in times):
+        if not all(time >= 0 for time in times):
             raise ValueError("Times supplied must have positive values.")
 
-        if any (time!=sort_time for time,sort_time in zip(times,sorted(times))):
+        if any(time != sort_time for time, sort_time in zip(times, sorted(times))):
             raise ValueError("Times supplied should be in an ascending order.")
-        
         return True
 
     @property

--- a/pydy/system.py
+++ b/pydy/system.py
@@ -354,10 +354,10 @@ class System(object):
         if len(times.shape) == 0:
             raise TypeError("Times supplied should be in an array_like format.")
 
-        if not all(time >= 0 for time in times):
+        if not np.all(times >= 0):
             raise ValueError("Times supplied must have positive values.")
 
-        if any(time != sort_time for time, sort_time in zip(times, sorted(times))):
+        if not np.all(np.diff(times) >= 0):
             raise ValueError("Times supplied should be in an ascending order.")
 
         return True

--- a/pydy/system.py
+++ b/pydy/system.py
@@ -340,22 +340,25 @@ class System(object):
         equations of motion are integrated, numerically.
 
         The object should be in a format which the integration module to be
-        used can accept. Since this attribute is not checked for
-        compatibility, the user becomes responsible to supply it correctly.
+        used can accept.
         """
         return self._times
 
     @times.setter
     def times(self, new_times):
+        self._check_times(new_times)
         self._times = new_times
 
     def _check_times(self, times):
-        """
-        Very basic checking.
-        TODO: add more checking
-        """
         if len(times) == 0:
             raise TypeError("Times supplied should be in an array_like format.")
+
+        if not all(time>=0 for time in times):
+            raise ValueError("Times supplied must have positive values.")
+
+        if any (time!=sort_time for time,sort_time in zip(times,sorted(times))):
+            raise ValueError("Times supplied should be in an ascending order.")
+        
         return True
 
     @property

--- a/pydy/tests/test_system.py
+++ b/pydy/tests/test_system.py
@@ -7,15 +7,17 @@ from numpy import testing
 import sympy as sm
 from sympy.physics.mechanics import dynamicsymbols
 from scipy.integrate import odeint
-theano = sm.external.import_module('theano')
 
 from ..system import System
 from ..models import multi_mass_spring_damper, n_link_pendulum_on_cart
 from ..utils import sympy_equal_to_or_newer_than, PyDyImportWarning
 
+theano = sm.external.import_module('theano')
+
 SYMPY_VERSION = sm.__version__
 
 warnings.simplefilter('once', PyDyImportWarning)
+
 
 class TestSystem():
 
@@ -262,9 +264,9 @@ class TestSystem():
         sys.integrate()
 
     def test_times(self):
-        times1 = [0,1,2,3,4,5,6,7,8,9]
-        times2 = [0,-2,7,3,-5]
-        times3 = [1,2,7,4,5]
+        times1 = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+        times2 = [0, -2, 7, 3, -5]
+        times3 = [1, 2, 7, 4, 5]
         times4 = 4
 
         sys = System(self.kane, times=times1)

--- a/pydy/tests/test_system.py
+++ b/pydy/tests/test_system.py
@@ -269,7 +269,7 @@ class TestSystem():
         times4 = 4
 
         sys = System(self.kane, times=times1)
-        assert sys.times == times1
+        testing.assert_allclose(sys.times, times1)
 
         with testing.assert_raises(ValueError):
             sys.times = times2

--- a/pydy/tests/test_system.py
+++ b/pydy/tests/test_system.py
@@ -51,6 +51,7 @@ class TestSystem():
         assert sys.specifieds == dict()
         assert sys.initial_conditions == dict()
         assert sys.constants == dict()
+        assert sys.times == list()
 
         # Specify a bunch of attributes during construction.
         # --------------------------------------------------
@@ -259,6 +260,24 @@ class TestSystem():
                                   dynamicsymbols('v0'): -1.0}
         sys.times = times
         sys.integrate()
+
+    def test_times(self):
+        times1 = [0,1,2,3,4,5,6,7,8,9]
+        times2 = [0,-2,7,3,-5]
+        times3 = [1,2,7,4,5]
+        times4 = 4
+
+        sys = System(self.kane, times=times1)
+        assert sys.times == times1
+
+        with testing.assert_raises(ValueError):
+            sys.times = times2
+
+        with testing.assert_raises(ValueError):
+            sys.times = times3
+
+        with testing.assert_raises(TypeError):
+            sys.times = times4
 
     def test_ode_solver(self):
 

--- a/pydy/tests/test_system.py
+++ b/pydy/tests/test_system.py
@@ -7,12 +7,11 @@ from numpy import testing
 import sympy as sm
 from sympy.physics.mechanics import dynamicsymbols
 from scipy.integrate import odeint
+theano = sm.external.import_module('theano')
 
 from ..system import System
 from ..models import multi_mass_spring_damper, n_link_pendulum_on_cart
 from ..utils import sympy_equal_to_or_newer_than, PyDyImportWarning
-
-theano = sm.external.import_module('theano')
 
 SYMPY_VERSION = sm.__version__
 


### PR DESCRIPTION
Fixes #321.

- [x] There are no merge conflicts.
- [x] If there is a related issue, a reference to that issue is in the
  commit message.
- [x] Unit tests have been added for the bug. (Please reference the issue #
  in the unit test.)
- [x] The tests pass both locally (run `nosetests`) and on Travis CI.
- [x] The code follows PEP8 guidelines. (use a linter, e.g.
  [pylint](http://www.pylint.org), to check your code)
- [ ] The bug fix is documented in the [Release
  Notes](https://github.com/pydy/pydy#release-notes).
- [x] The code is backwards compatible. (All public methods/classes must
  follow deprecation cycles.)
- [x] All reviewer comments have been addressed.