### PR TITLE
Run visualization server in background thread

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -68,6 +68,7 @@ PyDy has hard dependencies on the following software\ [#]_:
 - NumPy_ >= 1.8.1
 - SciPy_ >= 0.13.3
 - SymPy_ >= 0.7.4.1
+- PyWin32 >= 219 (Windows Only)
 
 .. [#] setuptools >= 8.0 is required if development versions of SymPy are used.
 

--- a/appveyor/install.ps1
+++ b/appveyor/install.ps1
@@ -19,7 +19,7 @@ function InstallCondaPackages ($python_home, $spec) {
 
 function main () {
     UpdateConda $env:PYTHON
-    InstallCondaPackages $env:PYTHON "numpy scipy sympy cython nose coverage"
+    InstallCondaPackages $env:PYTHON "numpy scipy sympy cython pywin32 nose coverage"
 }
 
 main

--- a/pydy/viz/server.py
+++ b/pydy/viz/server.py
@@ -76,7 +76,7 @@ class Server(object):
         self.port = port
         self.directory = directory
 
-    def run_server(self):
+    def run_server(self, headless=False):
         # Change dir to static first.
         os.chdir(self.directory)
         print(os.getcwd())
@@ -95,7 +95,8 @@ class Server(object):
         url = "http://localhost:"+str(sa[1]) + "/index.html?load=" + \
               self.scene_file
         print(url)
-        webbrowser.open(url)
+        if not headless:
+            webbrowser.open(url)
         print("Hit Ctrl+C to stop the server...")
         signal.signal(signal.SIGINT, self._stop_server)
         self.httpd.serve()

--- a/setup.py
+++ b/setup.py
@@ -12,6 +12,14 @@ exec(open('pydy/version.py').read())
 # line is added.
 os.environ["MPLCONFIGDIR"] = "."
 
+
+install_requires=['numpy>=1.8.1',
+                  'scipy>=0.13.3',
+                  'sympy>=0.7.4.1']
+
+if os.name == 'nt':
+    install_requires.append('PyWin32>=219')
+
 setup(
     name='pydy',
     version=__version__,
@@ -23,10 +31,7 @@ setup(
     keywords="multibody dynamics",
     license='LICENSE.txt',
     packages=find_packages(),
-    install_requires=['numpy>=1.8.1',
-                      'scipy>=0.13.3',
-                      'sympy>=0.7.4.1',
-                      ],
+    install_requires=install_requires,
     extras_require={'doc': ['sphinx', 'numpydoc'],
                     'codegen': ['Cython>=0.20.1',
                                 'Theano>=0.7.0'],


### PR DESCRIPTION
This PR runs the visualization server in a background thread instead of the main thread. An option to skip launching the web browser has also been added for debugging.

This will make testing the server easier as the server can be gracefully stopped.

- [x] There are no merge conflicts.
- [ ] If there is a related issue, a reference to that issue is in the
  commit message.
- [ ] Unit tests have been added for the bug. (Please reference the issue #
  in the unit test.)
- [x] The tests pass both locally (run `nosetests`) and on Travis CI.
- [x] The code follows PEP8 guidelines. (use a linter, e.g.
  [pylint](http://www.pylint.org), to check your code)
- [ ] The bug fix is documented in the [Release
  Notes](https://github.com/pydy/pydy#release-notes).
- [x] The code is backwards compatible. (All public methods/classes must
  follow deprecation cycles.)
- [x] All reviewer comments have been addressed.