### PR TITLE
Param to stop server without confirmation on KeyboardInterrupt (Ctrl + C).

### DIFF
--- a/pydy/viz/server.py
+++ b/pydy/viz/server.py
@@ -71,10 +71,14 @@ class Server(object):
     >>> server.run_server()
 
     """
-    def __init__(self, scene_file, directory="static/", port=8000):
+    def __init__(self, scene_file, directory="static/", port=8000,
+                 hard_stop=False):
         self.scene_file = scene_file
         self.port = port
         self.directory = directory
+        self.httpd = None
+        self._thread = None
+        self.hard_stop = hard_stop
 
     def run_server(self):
         # Change dir to static first.
@@ -114,10 +118,15 @@ class Server(object):
             Required by signal.signal
 
         """
-        res = raw_input("Shutdown this visualization server ([y]/n)? ")
-        if not res or res[0].lower() == 'y':
-            print("Shutdown confirmed")
-            print("Shutting down server...")
-            self.httpd.stop()
+        if not self.hard_stop:
+            res = raw_input("Shutdown this visualization server ([y]/n)? ")
+            if not res or res[0].lower() == 'y':
+                print("Shutdown confirmed")
+                print("Shutting down server...")
+                self.httpd.stop()
+                self._thread.join()
+            else:
+                print("Resuming operations...")
         else:
-            print("Resuming operations...")
+            self.httpd.stop()
+            self._thread.join()


### PR DESCRIPTION
- In the `pydy/viz/server.py` file, the `__init__` method of Server class is now modified to include a boolean parameter - **hard_stop**.

- It is set to `False` by default. This means if unaltered, the Server functions as it was before this PR.
 If set True, the server will stop without confirmation on SIGINT (KeyboardInterrupt). This means it won't display "_Shutdown this visualization server ([y]/n)?_" message and wait for confirmation.

- This parameter is specifically beneficial for passing tests, as asking for confirmation and waiting for a yes generates an unexpected `EOF Error`, which fails the tests. Hence this param `hard_stop` is set `True` explicitly while testing. 

- It depends on user what to do. If one does nothing, the Server will still ask for confirmation on pressing `Ctrl + C` as before.

- Also, in my opinion the confirmation part should be removed as nobody presses `Ctrl + C` by mistake and the server shuts down automatically. Neither does one change the decision of **not** shutting down the server at the last moment.

- It seems kind of tedious to first press `Ctrl + C` and then `y` or `Y` to stop the server. Also, it sometimes is a bit uncomfortable as it doesn't accept a `YES` or `Yes` or any other alternate other than **strictly** - `y`.