### PR TITLE
The width of the simulation canvas is now bounded by the Jupyter notebook borders.

### DIFF
--- a/pydy/viz/scene.py
+++ b/pydy/viz/scene.py
@@ -730,8 +730,6 @@ class Scene(object):
             # Construct a container that holds all of the constants input
             # text widgets.
             self._constants_container = widgets.Box()
-            self._constants_container._css = [("canvas", "width", "100%")]
-
             self._constants_text_widgets = OrderedDict()
             self._fill_constants_widgets()
             # Add all of the constants widgets to the container.
@@ -753,5 +751,10 @@ class Scene(object):
                                                  self._scene_json_file))
 
         self._html_widget = widgets.HTML(value=html)
+        # NOTE : This overrides the width of the simulation canvas so that it
+        # stays within the borders of the IPython notebook.
+        self._html_widget._css = [("canvas", "width", "100%"),
+                                  ("canvas", "padding-right", "10px")]
+
 
         display(self._html_widget)


### PR DESCRIPTION
- [x] There are no merge conflicts.
- [x] If there is a related issue, a reference to that issue is in the
  commit message.
- [ ] Unit tests have been added for the bug. (Please reference the issue #
  in the unit test.)
- [x] The tests pass both locally (run `nosetests`) and on Travis CI.
- [x] The code follows PEP8 guidelines. (use a linter, e.g.
  [pylint](http://www.pylint.org), to check your code)
- [ ] The bug fix is documented in the [Release
  Notes](https://github.com/pydy/pydy#release-notes).
- [x] The code is backwards compatible. (All public methods/classes must
  follow deprecation cycles.)
- [x] All reviewer comments have been addressed.

Fixes #236.

I checked this in IPython 3 and 4 and get the same result:

![selection_049](https://cloud.githubusercontent.com/assets/276007/13552531/c8b8a6b0-e31b-11e5-9e1f-44f06236448f.png)
