### PR TITLE
Fixes printing bug in the GUI for initial conditions.

### DIFF
--- a/pydy/viz/scene.py
+++ b/pydy/viz/scene.py
@@ -704,9 +704,13 @@ class Scene(object):
 
             val = self._system.initial_conditions[sym]
 
-            sym_0 = sym.xreplace({dynamicsymbols._t: self._system.times[0]})
-
-            desc = latex(sym_0, mode='inline')
+            # TODO : There should be a better way to do this. It would be nice
+            # to format the float in a away that always prints compactly and
+            # gives enough information even if the number is a very small or
+            # very large value.
+            desc = latex(sym, mode='inline')
+            desc = desc.replace(r'\left ({} \right )'.format(dynamicsymbols._t),
+                                '({:1.2f})'.format(self._system.times[0]))
 
             text_widget = widgets.FloatText(value=val,
                                             description=desc)


### PR DESCRIPTION
My previous implementation doesn't work as expected so I rewrote this to do a
simple replacement on the latex string that seems to work reliably. This stuff,
of course needs unit tests but we need to figure out how to text the notebook
output first.

- [x] There are no merge conflicts.
- [x] If there is a related issue, a reference to that issue is in the
  commit message.
- [ ] Unit tests have been added for the bug. (Please reference the issue #
  in the unit test.)
- [x] The tests pass both locally (run `nosetests`) and on Travis CI.
- [x] The code follows PEP8 guidelines. (use a linter, e.g.
  [pylint](http://www.pylint.org), to check your code)
- [ ] The bug fix is documented in the [Release
  Notes](https://github.com/pydy/pydy#release-notes).
- [x] The code is backwards compatible. (All public methods/classes must
  follow deprecation cycles.)
- [ ] All reviewer comments have been addressed.