### PR TITLE
Separate System from *Method

### DIFF
--- a/examples/chaos_pendulum/chaos_pendulum.ipynb
+++ b/examples/chaos_pendulum/chaos_pendulum.ipynb
@@ -1491,7 +1491,7 @@
     "def plot():\n",
     "    plt.figure()\n",
     "    plt.plot(sys.times, np.rad2deg(x[:, :2]))\n",
-    "    plt.legend([sym.latex(s, mode='inline') for s in sys.coordinates])\n",
+    "    plt.legend([sym.latex(s, mode='inline') for s in sys.states])\n",
     "plot()"
    ]
   },

--- a/examples/chaos_pendulum/chaos_pendulum.py
+++ b/examples/chaos_pendulum/chaos_pendulum.py
@@ -125,7 +125,7 @@ x = sys.integrate()
 
 
 plt.plot(sys.times, x)
-plt.legend([sym.latex(s, mode='inline') for s in sys.coordinates + sys.speeds])
+plt.legend([sym.latex(s, mode='inline') for s in sys.states])
 
 # visualize
 

--- a/examples/vanderpol/vanderpol.py
+++ b/examples/vanderpol/vanderpol.py
@@ -1,0 +1,18 @@
+import numpy as np, sympy as sp, matplotlib.pyplot as plt, numpy.matlib
+from pydy.system import System
+from sympy.physics.mechanics import dynamicsymbols
+
+x = sp.Matrix(dynamicsymbols('x1:3'))
+x1, x2 = x
+
+e = sp.symbols('epsilon')
+
+sys = System(x, sp.Matrix([x2, -x1+e*(1-x1**2)*x2]))
+
+sys.constants = {e: 5}
+sys.initial_conditions = {x1: 1, x2: 1}
+sys.times = np.linspace(0, 10, 500)
+res = sys.integrate()
+
+plt.plot(sys.times,res)
+plt.legend([sp.latex(s, mode='inline') for s in sys.states])

--- a/pydy/codegen/ode_function_generators.py
+++ b/pydy/codegen/ode_function_generators.py
@@ -169,8 +169,8 @@ r : dictionary
         full mass matrix
             M(x, p) * x' = f(x, t, r, p)
         min mass matrix
-            M(q, p) * u' = f(q, u, t, r, p)
-            q' = g(q, u, t)
+            M(x, p) * x'_d = f(x, t, r, p)
+            x'_k = g(x, t)
 
         """
 
@@ -183,7 +183,7 @@ r : dictionary
 
         return system_type
 
-    def __init__(self, right_hand_side, coordinates, speeds, constants,
+    def __init__(self, right_hand_side, states, constants,
                  mass_matrix=None, coordinate_derivatives=None,
                  specifieds=None, linear_sys_solver='numpy',
                  constants_arg_type=None, specifieds_arg_type=None):
@@ -195,8 +195,8 @@ r : dictionary
 
             [2] M(x, p) x' = F(x, t, r, p)
 
-            [3] M(q, p) u' = F(q, u, t, r, p)
-                q' = G(q, u, t, r, p)
+            [3] M(x, p) x'_d = F(x, t, r, p)
+                x'_k = G(x, t, r, p)
 
         where
 
@@ -204,8 +204,6 @@ r : dictionary
             t : time
             r : specified (exogenous) inputs
             p : constants
-            q : generalized coordinates
-            u : generalized speeds
             M : mass matrix (full or minimum)
             F : right hand side (full or minimum)
             G : right hand side of the kinematical differential equations
@@ -221,12 +219,9 @@ r : dictionary
             right hand side has been solved for symbolically then only F is
             required, see form [1]; if not then the mass matrix must also be
             supplied, see forms [2, 3].
-        coordinates : sequence of SymPy Functions
-            The generalized coordinates. These must be ordered in the same
+        states : sequence of SymPy Functions
+            The states. These must be ordered in the same
             order as the rows in M, F, and/or G and be functions of time.
-        speeds : sequence of SymPy Functions
-            The generalized speeds. These must be ordered in the same order
-            as the rows in M, F, and/or G and be functions of time.
         constants : sequence of SymPy Symbols
             All of the constants present in the equations of motion. The
             order does not matter.
@@ -285,9 +280,7 @@ r : dictionary
         """
 
         self.right_hand_side = right_hand_side
-        self.coordinates = coordinates
-        self.speeds = speeds
-        self.constants = constants
+        self.states = states
         self.mass_matrix = mass_matrix
         self.coordinate_derivatives = coordinate_derivatives
         self.specifieds = specifieds
@@ -307,9 +300,7 @@ r : dictionary
             mass_matrix=mass_matrix,
             coordinate_derivatives=coordinate_derivatives)
 
-        self.num_coordinates = len(coordinates)
-        self.num_speeds = len(speeds)
-        self.num_states = self.num_coordinates + self.num_speeds
+        self.num_states = len(states)
         self.num_constants = len(constants)
 
         if self.specifieds is None:
@@ -347,9 +338,12 @@ r : dictionary
         if self.system_type == 'min mass matrix':
 
             nr, nc = self.mass_matrix.shape
-            assert self.num_speeds == nr == nc
-            assert self.num_speeds == self.right_hand_side.shape[0]
-            assert self.num_coordinates == self.coordinate_derivatives.shape[0]
+            assert nr == nc
+            assert nr == self.right_hand_side.shape[0]
+            assert self.num_states - nr == self.coordinate_derivatives.shape[0]
+
+            self.num_coordinates = self.coordinate_derivatives.shape[0]
+            self.num_speeds = self.num_states - self.num_coordinates
 
         elif self.system_type == 'full mass matrix':
 
@@ -486,8 +480,7 @@ r : dictionary
     def _generate_rhs_docstring(self):
 
         template_values = {'num_states': self.num_states,
-                           'state_list': self.list_syms(8, self.coordinates
-                                                        + self.speeds),
+                           'state_list': self.list_syms(8, self.states),
                            'specified_call_sig': '',
                            'constants_explanation':
                                self._constants_doc_templates[
@@ -523,10 +516,7 @@ r : dictionary
 
                 args = self._parse_all_args(*args)
 
-                q = args[0][:self.num_coordinates]
-                u = args[0][self.num_coordinates:]
-
-                xdot = self._base_rhs(q, u, *args[2:])
+                xdot = self._base_rhs(args[0], *args[2:])
 
                 return xdot
 
@@ -558,13 +548,10 @@ r : dictionary
             # or
             # args: x, t, r, p
 
-            q = args[0][:self.num_coordinates]
-            u = args[0][self.num_coordinates:]
-
             if self.specifieds is None:
-                return self._base_rhs(q, u, p(*args))
+                return self._base_rhs(args[0], p(*args))
             else:
-                return self._base_rhs(q, u, r(*args), p(*args))
+                return self._base_rhs(args[0], r(*args), p(*args))
 
         rhs.__doc__ = self._generate_rhs_docstring()
 
@@ -572,7 +559,7 @@ r : dictionary
 
     def _create_base_rhs_function(self):
         """Sets the self._base_rhs function. This function accepts arguments
-        in this form: (q, u, p) or (q, u, r, p)."""
+        in this form: (x, p) or (x, r, p)."""
 
         if self.system_type == 'full rhs':
 
@@ -604,10 +591,10 @@ r : dictionary
             self._base_rhs = base_rhs
 
     def define_inputs(self):
-        """Sets self.inputs to the list of sequences [q, u, p] or [q, u, r,
+        """Sets self.inputs to the list of sequences [x, p] or [x, r,
         p]."""
 
-        self.inputs = [self.coordinates, self.speeds, self.constants]
+        self.inputs = [self.states, self.constants]
         if self.specifieds is not None:
             self.inputs.insert(2, self.specifieds)
 
@@ -655,9 +642,9 @@ class CythonODEFunctionGenerator(ODEFunctionGenerator):
     def _set_eval_array(self, f):
 
         if self.specifieds is None:
-            self.eval_arrays = lambda q, u, p: f(q, u, p, *self._empties)
+            self.eval_arrays = lambda x, p: f(x, p, *self._empties)
         else:
-            self.eval_arrays = lambda q, u, r, p: f(q, u, r, p,
+            self.eval_arrays = lambda x, r, p: f(x, r, p,
                                                     *self._empties)
 
     def generate_full_rhs_function(self):
@@ -689,7 +676,7 @@ class CythonODEFunctionGenerator(ODEFunctionGenerator):
 
         mass_matrix_result = np.empty(self.num_speeds ** 2, dtype=float)
         rhs_result = np.empty(self.num_speeds, dtype=float)
-        kin_diffs_result = np.empty(self.num_coordinates, dtype=float)
+        kin_diffs_result = np.empty(self.states - self.num_speeds, dtype=float)
         self._empties = (mass_matrix_result, rhs_result, kin_diffs_result)
 
         self._set_eval_array(self._cythonize(outputs, self.inputs))
@@ -704,9 +691,9 @@ class LambdifyODEFunctionGenerator(ODEFunctionGenerator):
         subs = {}
         vec_inputs = []
         if self.specifieds is None:
-            def_vecs = ['q', 'u', 'p']
+            def_vecs = ['x', 'p']
         else:
-            def_vecs = ['q', 'u', 'r', 'p']
+            def_vecs = ['x', 'r', 'p']
 
         for syms, vec_name in zip(self.inputs, def_vecs):
             v = sm.DeferredVector(vec_name)
@@ -732,9 +719,9 @@ class LambdifyODEFunctionGenerator(ODEFunctionGenerator):
         f = self._lambdify(outputs)
 
         if self.specifieds is None:
-            self.eval_arrays = lambda q, u, p: np.squeeze(f(q, u, p))
+            self.eval_arrays = lambda x, p: np.squeeze(f(x, p))
         else:
-            self.eval_arrays = lambda q, u, r, p: np.squeeze(f(q, u, r, p))
+            self.eval_arrays = lambda x, r, p: np.squeeze(f(x, r, p))
 
     def generate_full_mass_matrix_function(self):
 
@@ -744,11 +731,11 @@ class LambdifyODEFunctionGenerator(ODEFunctionGenerator):
         f = self._lambdify(outputs)
 
         if self.specifieds is None:
-            self.eval_arrays = lambda q, u, p: tuple([np.squeeze(o) for o in
-                                                      f(q, u, p)])
+            self.eval_arrays = lambda x, p: tuple([np.squeeze(o) for o in
+                                                      f(x, p)])
         else:
-            self.eval_arrays = lambda q, u, r, p: tuple([np.squeeze(o) for o
-                                                         in f(q, u, r, p)])
+            self.eval_arrays = lambda x, r, p: tuple([np.squeeze(o) for o
+                                                         in f(x, r, p)])
 
     def generate_min_mass_matrix_function(self):
 
@@ -759,11 +746,11 @@ class LambdifyODEFunctionGenerator(ODEFunctionGenerator):
         f = self._lambdify(outputs)
 
         if self.specifieds is None:
-            self.eval_arrays = lambda q, u, p: tuple([np.squeeze(o) for o in
-                                                      f(q, u, p)])
+            self.eval_arrays = lambda x, p: tuple([np.squeeze(o) for o in
+                                                      f(x, p)])
         else:
-            self.eval_arrays = lambda q, u, r, p: tuple([np.squeeze(o) for o
-                                                         in f(q, u, r, p)])
+            self.eval_arrays = lambda x, r, p: tuple([np.squeeze(o) for o
+                                                         in f(x, r, p)])
 
 
 class TheanoODEFunctionGenerator(ODEFunctionGenerator):
@@ -783,8 +770,7 @@ class TheanoODEFunctionGenerator(ODEFunctionGenerator):
         specifieds = []
         if self.specifieds is not None:
             specifieds = self.specifieds
-        self.inputs = chain(self.coordinates, self.speeds,
-                            specifieds, self.constants)
+        self.inputs = chain(x, specifieds, self.constants)
 
     def _theanoize(self, outputs):
 

--- a/pydy/system.py
+++ b/pydy/system.py
@@ -52,10 +52,11 @@ you must call ``generate_ode_function`` on your own::
 """
 import warnings
 from itertools import repeat
+from inspect import signature
 
 import numpy as np
 import sympy as sm
-from sympy.physics.mechanics import dynamicsymbols
+from sympy.physics.mechanics import dynamicsymbols, KanesMethod
 from scipy.integrate import odeint
 
 from .codegen.ode_function_generators import generate_ode_function
@@ -82,6 +83,9 @@ class System(object):
     eom_method : sympy.physics.mechanics.KanesMethod
         You must have called ``KanesMethod.kanes_equations()`` *before*
         constructing this ``System``.
+
+    OR
+
     constants : dict, optional (default: all 1.0)
         This dictionary maps SymPy Symbol objects to floats.
     specifieds : dict, optional (default: all 0)
@@ -97,14 +101,36 @@ class System(object):
         System.integrate() can be called.
 
     """
-    def __init__(self, eom_method, constants=None, specifieds=None,
-                 ode_solver=None, initial_conditions=None, times=None):
+    def __init__(self, *args, constants=None, specifieds=None, ode_solver=None,
+                 initial_conditions=None, times=None, **kwargs):
 
-        self._eom_method = eom_method
+        if len(args)+len(kwargs)==1:
+            if len(args)==1:
+                eom_method = args[0]
+            else:
+                eom_method = kwargs['eom_method']
+
+            if sympy_equal_to_or_newer_than('0.7.6'):
+                coordinates = eom_method.q[:] # coordinates
+                speeds = eom_method.u[:] # speeds
+            else:
+                coordinates = eom_method._q
+                speeds = eom_method._u
+
+            self.states = coordinates + speeds
+            self.force = eom_method.forcing_full
+            self.mass = eom_method.mass_matrix_full
+        elif len(args)+len(kwargs)==3:
+            sig = signature(lambda states, force, mass: None)
+            bound_args = sig.bind(*args,**kwargs)
+            states = bound_args.arguments['states']
+            force = bound_args.arguments['force']
+            mass = bound_args.arguments['mass']
+
 
         # TODO : What if user adds symbols after constructing a System?
-        self._constants_symbols = self._Kane_constant_symbols()
-        self._specifieds_symbols = self._Kane_undefined_dynamicsymbols()
+        self._constants_symbols = self._constant_symbols()
+        self._specifieds_symbols = self._undefined_dynamicsymbols()
 
         if constants is None:
             self.constants = dict()
@@ -132,43 +158,6 @@ class System(object):
             self._times = times
 
         self._evaluate_ode_function = None
-
-    @property
-    def coordinates(self):
-        """Returns a list of the symbolic functions of time representing the
-        system's generalized coordinates."""
-        if sympy_equal_to_or_newer_than('0.7.6'):
-            return self.eom_method.q[:]
-        else:
-            return self.eom_method._q
-
-    @property
-    def speeds(self):
-        """Returns a list of the symbolic functions of time representing the
-        system's generalized speeds."""
-        if sympy_equal_to_or_newer_than('0.7.6'):
-            return self.eom_method.u[:]
-        else:
-            return self.eom_method._u
-
-    @property
-    def states(self):
-        """Returns a list of the symbolic functions of time representing the
-        system's states, i.e. generalized coordinates plus the generalized
-        speeds. These are in the same order as used in integration (as
-        passed into evaluate_ode_function) and match the order of the mass
-        matrix and forcing vector.
-
-        """
-        return self.coordinates + self.speeds
-
-    @property
-    def eom_method(self):
-        """This is a sympy.physics.mechanics.KanesMethod. The method used to
-        generate the equations of motion. Read-only.
-
-        """
-        return self._eom_method
 
     @property
     def constants(self):
@@ -429,9 +418,8 @@ class System(object):
 
         """
 
-        args = (self.eom_method.forcing_full,
-                self.coordinates,
-                self.speeds,
+        args = (self.force,
+                self.states,
                 self.constants_symbols)
 
         return args
@@ -452,7 +440,7 @@ class System(object):
         if not specifieds:
             specifieds = None
 
-        kwargs = {'mass_matrix': self.eom_method.mass_matrix_full,
+        kwargs = {'mass_matrix': self.mass,
                   'specifieds': specifieds}
 
         return kwargs
@@ -548,32 +536,7 @@ class System(object):
 
         return x_history
 
-    def _Kane_inlist_insyms(self):
-        """TODO temporary."""
-
-        uaux = self.eom_method._uaux[:]
-        uauxdot = [sm.diff(i, dynamicsymbols._t) for i in uaux]
-
-        # Checking for dynamic symbols outside the dynamic differential
-        # equations; throws error if there is.
-
-        if sympy_equal_to_or_newer_than('0.7.6'):
-            # TODO : KanesMethod should provide public attributes for qdot,
-            # udot, uaux, and uauxdot.
-            insyms = set(self.eom_method.q[:] + self.eom_method._qdot[:] +
-                         self.eom_method.u[:] + self.eom_method._udot[:] +
-                         uaux + uauxdot)
-        else:
-            insyms = set(self.eom_method._q + self.eom_method._qdot +
-                         self.eom_method._u + self.eom_method._udot + uaux +
-                         uauxdot)
-
-        inlist = (self.eom_method.forcing_full[:] +
-                  self.eom_method.mass_matrix_full[:])
-
-        return inlist, insyms
-
-    def _Kane_undefined_dynamicsymbols(self):
+    def _undefined_dynamicsymbols(self):
         """Similar to ``_find_dynamicsymbols()``, except that it checks all
         syms used in the system. Code is copied from ``linearize()``.
 
@@ -581,18 +544,18 @@ class System(object):
         interface for obtaining these quantities.
 
         """
-        from_eoms, from_sym_lists = self._Kane_inlist_insyms()
         if sympy_equal_to_or_newer_than('0.7.6'):
             functions_of_time = set()
-            for expr in from_eoms:
+            for expr in (self.force[:] + self.mass[:]):
                 functions_of_time = functions_of_time.union(
                     find_dynamicsymbols(expr))
-            return functions_of_time.difference(from_sym_lists)
+            return functions_of_time.difference(set(self.states))
         else:
-            return set(self.eom_method._find_dynamicsymbols(
-                *self._Kane_inlist_insyms()))
+            return set(KanesMethod._find_dynamicsymbols(
+                    (self.force[:] + self.mass[:]), set(self.states)
+                ))
 
-    def _Kane_constant_symbols(self):
+    def _constant_symbols(self):
         """Similar to ``_find_othersymbols()``, except it checks all syms used in
         the system.
 
@@ -601,14 +564,13 @@ class System(object):
         TODO temporary.
 
         """
-        from_eoms, from_sym_lists = self._Kane_inlist_insyms()
         if sympy_equal_to_or_newer_than('0.7.6'):
             unique_symbols = set()
-            for expr in from_eoms:
+            for expr in (self.force[:] + self.mass[:]):
                 unique_symbols = unique_symbols.union(expr.free_symbols)
             constants = unique_symbols
         else:
-            constants = set(self.eom_method._find_othersymbols(
-                *self._Kane_inlist_insyms()))
+            constants = set(KanesMethod._find_othersymbols(
+                (self.force[:] + self.mass[:]), set(self.states) ))
         constants.remove(dynamicsymbols._t)
         return constants

--- a/pydy/viz/scene.py
+++ b/pydy/viz/scene.py
@@ -700,7 +700,7 @@ class Scene(object):
 
     def _fill_initial_conditions_widgets(self):
 
-        for sym in self._system.coordinates + self._system.speeds:
+        for sym in self._system.states:
 
             val = self._system.initial_conditions[sym]
 


### PR DESCRIPTION
This is a running PR to separate out the `System` class from the `*Method` classes as discussed in [an email discussion](https://groups.google.com/d/topic/pydy/n6h-dIaHyy0/discussion) and on gitter. My suggestion is that `System` holds onto the vector of states, the vector of expressions for "force" (or is it a generalized impulse?), and optionally a mass matrix. The changes are small, but the decoupling allows for creating a system with manually defined equations as shown in the Van Der Pol example.

If this looks good, I can go ahead and complete the PR (tests and documentation). Actually, I may need help formulating the tests.

Right now, `System` can be instantiated using the old signature of passing a `*Method` instance, as long as it `*Method.q` and `*Method.u` form the states, `*Method.forcing_full` forms the RHS, and `*Method.mass_matrix_full` forms the mass matrix.
- [x] There are no merge conflicts.
- [x] If there is a related issue, a reference to that issue is in the
  commit message.
- [ ] Unit tests have been added for the new feature.
- [ ] The PR passes tests both locally (run `nosetests`) and on Travis CI.
- [x] All public methods and classes have docstrings. (We use the [numpydoc
  format](https://github.com/numpy/numpy/blob/master/doc/HOWTO_DOCUMENT.rst.txt).)
- [ ] An explanation has been added to the online documentation. (`docs`
  directory)
- [ ] The code follows PEP8 guidelines. (use a linter, e.g.
  [pylint](http://www.pylint.org), to check your code)
- [ ] The new feature is documented in the [Release
  Notes](https://github.com/pydy/pydy#release-notes).
- [x] The code is backwards compatible. (All public methods/classes must
  follow deprecation cycles.)
- [ ] All reviewer comments have been addressed.
