### PR TITLE
Fix multiarray import error on appveyor

### DIFF
--- a/appveyor/install.ps1
+++ b/appveyor/install.ps1
@@ -19,7 +19,7 @@ function InstallCondaPackages ($python_home, $spec) {
 
 function main () {
     UpdateConda $env:PYTHON
-    InstallCondaPackages $env:PYTHON "numpy scipy sympy cython pywin32 nose coverage"
+    InstallCondaPackages $env:PYTHON "numpy scipy sympy cython pywin32 nose coverage msvc_runtime"
 }
 
 main


### PR DESCRIPTION
Fix numpy multiarray import error for Python < 3.5 in appveyor builds.
Refer to: https://github.com/matplotlib/matplotlib/issues/6115