### PR TITLE
kwargs can be passed from System.generate_ode_function to the matrix generator

### DIFF
--- a/pydy/codegen/ode_function_generators.py
+++ b/pydy/codegen/ode_function_generators.py
@@ -641,6 +641,13 @@ class CythonODEFunctionGenerator(ODEFunctionGenerator):
 
     def __init__(self, *args, **kwargs):
 
+        self._options = {'tmp_dir': None,
+                         'prefix': 'pydy_codegen',
+                         'cse': True,
+                         'verbose': False}
+        for k, v in self._options.items():
+            self._options[k] = kwargs.pop(k, v)
+
         if Cython is None:
             raise ImportError('Cython must be installed to use this class.')
         else:
@@ -648,9 +655,12 @@ class CythonODEFunctionGenerator(ODEFunctionGenerator):
 
     __init__.__doc__ = ODEFunctionGenerator.__init__.__doc__
 
-    @staticmethod
-    def _cythonize(outputs, inputs):
-        return CythonMatrixGenerator(inputs, outputs).compile()
+    def _cythonize(self, outputs, inputs):
+        g = CythonMatrixGenerator(inputs, outputs,
+                                  prefix=self._options['prefix'],
+                                  cse=self._options['cse'])
+        return g.compile(tmp_dir=self._options['tmp_dir'],
+                         verbose=self._options['verbose'])
 
     def _set_eval_array(self, f):
 

--- a/pydy/system.py
+++ b/pydy/system.py
@@ -459,8 +459,8 @@ class System(object):
 
     def generate_ode_function(self, **kwargs):
         """Calls ``pydy.codegen.ode_function_generators.generate_ode_function``
-        with the appropriate arguments, and sets the
-        ``evaluate_ode_function`` attribute to the resulting function.
+        with the appropriate arguments, and sets the ``evaluate_ode_function``
+        attribute to the resulting function.
 
         Parameters
         ----------

--- a/pydy/tests/test_system.py
+++ b/pydy/tests/test_system.py
@@ -431,11 +431,12 @@ class TestSystem():
         # Test pass kwargs to the generators.
         if Cython:
             self.tempdirpath = tempfile.mkdtemp()
+            prefix = 'my_test_file'
             self.sys.generate_ode_function(generator='cython',
-                                           prefix='my_test_file',
+                                           prefix=prefix,
                                            tmp_dir=self.tempdirpath)
-            assert os.path.isfile(os.path.join(self.tempdirpath,
-                                               'my_test_file_0_c.c'))
+            assert [True for f in os.listdir(self.tempdirpath)
+                    if f.startswith(prefix)]
         else:
             warnings.warn("Cython was not found so the related tests are being"
                           " skipped.", PyDyImportWarning)


### PR DESCRIPTION
This implements an _options attribute to the subclass of ODEFunctionGenerator
and thus allows various options needed for a specific MatrixGenerator to be
supplied all the way at the System.generate_ode_function and
generate_ode_function levels.

- [ ] There are no merge conflicts.
- [ ] If there is a related issue, a reference to that issue is in the
  commit message.
- [ ] Unit tests have been added for the new feature.
- [ ] The PR passes tests both locally (run `nosetests`) and on Travis CI.
- [ ] All public methods and classes have docstrings. (We use the [numpydoc
  format](https://github.com/numpy/numpy/blob/master/doc/HOWTO_DOCUMENT.rst.txt).)
- [ ] An explanation has been added to the online documentation. (`docs`
  directory)
- [ ] The code follows PEP8 guidelines. (use a linter, e.g.
  [pylint](http://www.pylint.org), to check your code)
- [ ] The new feature is documented in the [Release
  Notes](https://github.com/pydy/pydy#release-notes).
- [ ] The code is backwards compatible. (All public methods/classes must
  follow deprecation cycles.)
- [ ] All reviewer comments have been addressed.

@asmeurer This fixes the issue you had this morning.