### PR TITLE
Update matrix_generator.py

### DIFF
--- a/pydy/codegen/matrix_generator.py
+++ b/pydy/codegen/matrix_generator.py
@@ -53,7 +53,7 @@ class MatrixGenerator(object):
             required_args |= set().union(*[i.free_symbols for i in matrix])
             required_args |= find_dynamicsymbols(matrix)
 
-        required_args.remove(me.dynamicsymbols._t)
+        required_args.discard(me.dynamicsymbols._t)
 
         all_arguments = set(itertools.chain(*arguments))
 


### PR DESCRIPTION
The remove function from the set class raises an error when the argument is not in the set. I have changed it to the discard function, which does the same thing but does not raise the error. This is useful if you create custom matrices that do not have the symbol t.

Please edit below based on the type of PR. It is then the duty of reviewers to check off the items as they are completed. If any questions are not relevant to your particular pull request, a reviewer will simply check it off as done.

Bug Fix
-------

   - [ ] There are no merge conflicts.
   - [ ] If there is a related issue, a reference to that issue is in the
     commit message.
   - [ ] Unit tests have been added for the bug. (Please reference the issue #
     in the unit test.)
   - [ ] The tests pass both locally (run `nosetests`) and on Travis CI.
   - [ ] The code follows PEP8 guidelines. (use a linter, e.g.
     [pylint](http://www.pylint.org), to check your code)
   - [ ] The bug fix is documented in the [Release
     Notes](https://github.com/pydy/pydy#release-notes).
   - [ ] The code is backwards compatible. (All public methods/classes must
     follow deprecation cycles.)
   - [ ] All reviewer comments have been addressed.