### PR TITLE
Drop Python 3.5 from Travis tests.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ python:
   - 2.7
   - 3.6
   - 3.7
-  - 3.8
 env:
   matrix:
   - DEP_VERSIONS="oldest"  # Approximately the versions available in the last LTS release of Ubuntu, currently 18.04 LTS.

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,12 +35,12 @@ install:
       conda install numpy=1.13 scipy=0.19 sympy=1.1 cython=0.26 theano=0.9 pip coverage nose flake8 matplotlib sphinx "numpydoc<1";
     elif [[ $DEP_VERSIONS == "latest" ]] && [[ $TRAVIS_PYTHON_VERSION == 3.* ]]; then
       conda install numpy scipy sympy cython theano pythreejs pip coverage nose flake8 matplotlib sphinx numpydoc jupyter_sphinx ;
-    elif [[ $DEP_VERSIONS == "latest" ]]; then  # py27
+    elif [[ $DEP_VERSIONS == "latest" ]]; then
       conda install numpy scipy sympy cython theano pythreejs pip coverage nose flake8 matplotlib sphinx "numpydoc<1";
     elif [[ $DEP_VERSIONS == "master" ]] && [[ $TRAVIS_PYTHON_VERSION == 3.* ]]; then
       conda install numpy scipy mpmath fastcache cython theano pythreejs pip coverage nose flake8 matplotlib sphinx numpydoc jupyter_sphinx;
       pip install https://github.com/sympy/sympy/archive/master.zip;
-    elif [[ $DEP_VERSIONS == "master" ]]; then  # py27
+    elif [[ $DEP_VERSIONS == "master" ]]; then
       conda install "sympy=1.5" numpy scipy mpmath fastcache cython theano pythreejs pip coverage nose flake8 matplotlib sphinx "numpydoc<1";
     fi
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ before_install:
   - conda update -q conda
 install:
   - sudo apt-get install phantomjs
-  - conda create -q -n test-env python=$TRAVIS_PYTHON_VERSION pip coverage nose flake8 matplotlib sphinx "numpydoc<1"
+  - conda create -q -n test-env python=$TRAVIS_PYTHON_VERSION
   - source activate test-env
   # NOTE : There is a bug in SymPy 1.1.1 that prevents the jupyter_sphinx
   # examples from building, so don't install jupyter_sphinx in oldest so it is
@@ -31,23 +31,23 @@ install:
   # NOTE : SymPy's master branch will no longer install with Python 2.7. The
   # last supported version is SymPy 1.5.
   - if [[ $DEP_VERSIONS == "oldest" ]]; then
-      conda install numpy=1.13 scipy=0.19 sympy=1.1 cython=0.26 theano=0.9;
+      conda install numpy=1.13 scipy=0.19 sympy=1.1 cython=0.26 theano=0.9 pip coverage nose flake8 matplotlib sphinx "numpydoc<1";
     elif [[ $DEP_VERSIONS == "latest" ]] && [[ $TRAVIS_PYTHON_VERSION == 3.5 ]]; then
-      conda install numpy scipy sympy cython theano pythreejs;
+      conda install numpy scipy sympy cython theano pythreejs pip coverage nose flake8 matplotlib sphinx "numpydoc<1";
       pip install jupyter-sphinx;
     elif [[ $DEP_VERSIONS == "latest" ]] && [[ $TRAVIS_PYTHON_VERSION == 3.* ]]; then
-      conda install numpy scipy sympy cython theano pythreejs jupyter_sphinx;
+      conda install numpy scipy sympy cython theano pythreejs jupyter_sphinx pip coverage nose flake8 matplotlib sphinx "numpydoc<1";
     elif [[ $DEP_VERSIONS == "latest" ]]; then
-      conda install numpy scipy sympy cython theano pythreejs;
+      conda install numpy scipy sympy cython theano pythreejs pip coverage nose flake8 matplotlib sphinx "numpydoc<1";
     elif [[ $DEP_VERSIONS == "master" ]] && [[ $TRAVIS_PYTHON_VERSION == 3.5 ]]; then
-      conda install numpy scipy mpmath fastcache cython theano pythreejs;
+      conda install numpy scipy mpmath fastcache cython theano pythreejs pip coverage nose flake8 matplotlib sphinx "numpydoc<1";
       pip install jupyter-sphinx;
       pip install https://github.com/sympy/sympy/archive/master.zip;
     elif [[ $DEP_VERSIONS == "master" ]] && [[ $TRAVIS_PYTHON_VERSION == 3.* ]]; then
-      conda install numpy scipy mpmath fastcache cython theano pythreejs jupyter_sphinx;
+      conda install numpy scipy mpmath fastcache cython theano pythreejs jupyter_sphinx pip coverage nose flake8 matplotlib sphinx "numpydoc<1";
       pip install https://github.com/sympy/sympy/archive/master.zip;
     elif [[ $DEP_VERSIONS == "master" ]]; then
-      conda install "sympy=1.5" numpy scipy mpmath fastcache cython theano pythreejs;
+      conda install "sympy=1.5" numpy scipy mpmath fastcache cython theano pythreejs pip coverage nose flake8 matplotlib sphinx "numpydoc<1";
     fi
 before_script:
   - conda info

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ before_install:
   - conda update -q conda
 install:
   - sudo apt-get install phantomjs
-  - conda create -q -n test-env python=$TRAVIS_PYTHON_VERSION pip coverage nose flake8 matplotlib sphinx numpydoc
+  - conda create -q -n test-env python=$TRAVIS_PYTHON_VERSION pip coverage nose flake8 matplotlib sphinx "numpydoc<1"
   - source activate test-env
   # NOTE : There is a bug in SymPy 1.1.1 that prevents the jupyter_sphinx
   # examples from building, so don't install jupyter_sphinx in oldest so it is

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,26 +27,20 @@ install:
   - source activate test-env
   # NOTE : There is a bug in SymPy 1.1.1 that prevents the jupyter_sphinx
   # examples from building, so don't install jupyter_sphinx in oldest so it is
-  # skipped. Also, there are no Python 3.5 binaries for jupyter_sphinx on conda-forge.
+  # skipped.
   # NOTE : SymPy's master branch will no longer install with Python 2.7. The
   # last supported version is SymPy 1.5.
+  # NOTE : numpydoc dropped support for Python 2.7 in version 1.0.0.
   - if [[ $DEP_VERSIONS == "oldest" ]]; then
       conda install numpy=1.13 scipy=0.19 sympy=1.1 cython=0.26 theano=0.9 pip coverage nose flake8 matplotlib sphinx "numpydoc<1";
-    elif [[ $DEP_VERSIONS == "latest" ]] && [[ $TRAVIS_PYTHON_VERSION == 3.5 ]]; then
-      conda install numpy scipy sympy cython theano pythreejs pip coverage nose flake8 matplotlib sphinx "numpydoc<1";
-      pip install jupyter-sphinx;
     elif [[ $DEP_VERSIONS == "latest" ]] && [[ $TRAVIS_PYTHON_VERSION == 3.* ]]; then
-      conda install numpy scipy sympy cython theano pythreejs jupyter_sphinx pip coverage nose flake8 matplotlib sphinx "numpydoc<1";
-    elif [[ $DEP_VERSIONS == "latest" ]]; then
+      conda install numpy scipy sympy cython theano pythreejs pip coverage nose flake8 matplotlib sphinx numpydoc jupyter_sphinx ;
+    elif [[ $DEP_VERSIONS == "latest" ]]; then  # py27
       conda install numpy scipy sympy cython theano pythreejs pip coverage nose flake8 matplotlib sphinx "numpydoc<1";
-    elif [[ $DEP_VERSIONS == "master" ]] && [[ $TRAVIS_PYTHON_VERSION == 3.5 ]]; then
-      conda install numpy scipy mpmath fastcache cython theano pythreejs pip coverage nose flake8 matplotlib sphinx "numpydoc<1";
-      pip install jupyter-sphinx;
-      pip install https://github.com/sympy/sympy/archive/master.zip;
     elif [[ $DEP_VERSIONS == "master" ]] && [[ $TRAVIS_PYTHON_VERSION == 3.* ]]; then
-      conda install numpy scipy mpmath fastcache cython theano pythreejs jupyter_sphinx pip coverage nose flake8 matplotlib sphinx "numpydoc<1";
+      conda install numpy scipy mpmath fastcache cython theano pythreejs pip coverage nose flake8 matplotlib sphinx numpydoc jupyter_sphinx;
       pip install https://github.com/sympy/sympy/archive/master.zip;
-    elif [[ $DEP_VERSIONS == "master" ]]; then
+    elif [[ $DEP_VERSIONS == "master" ]]; then  # py27
       conda install "sympy=1.5" numpy scipy mpmath fastcache cython theano pythreejs pip coverage nose flake8 matplotlib sphinx "numpydoc<1";
     fi
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 language: python
 python:
   - 2.7
-  - 3.5
   - 3.6
   - 3.7
+  - 3.8
 env:
   matrix:
   - DEP_VERSIONS="oldest"  # Approximately the versions available in the last LTS release of Ubuntu, currently 18.04 LTS.

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,11 +12,6 @@ environment:
       PYTHON_ARCH: "64"
       CONDA_PY: "27"
 
-    - PYTHON: "C:\\Miniconda35-x64"
-      PYTHON_VERSION: "3.5"
-      PYTHON_ARCH: "64"
-      CONDA_PY: "35"
-
     - PYTHON: "C:\\Miniconda36-x64"
       PYTHON_VERSION: "3.6"
       PYTHON_ARCH: "64"

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -75,11 +75,11 @@ import numpydoc
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
 extensions = [
-    'numpydoc',
     'sphinx.ext.autodoc',
     'sphinx.ext.autosummary',
     'sphinx.ext.ifconfig',
     'sphinx.ext.viewcode',
+    'numpydoc',
 ]
 
 # NOTE : jupyter_sphinx is only available on Python 3.5+, make it an optional

--- a/pydy/codegen/c_code.py
+++ b/pydy/codegen/c_code.py
@@ -7,10 +7,14 @@ import os
 
 import sympy as sm
 try:
-    from sympy.printing.ccode import C99CodePrinter as CCodePrinter
-except ImportError:
-    # SymPy 1.0 and lower uses this version.
-    from sympy.printing.ccode import CCodePrinter
+    try:
+        from sympy.printing.ccode import C99CodePrinter as CCodePrinter
+    except ImportError:
+        # SymPy 1.0 and lower uses this version.
+        from sympy.printing.ccode import CCodePrinter
+except ModuleNotFoundError:
+    # SymPy > 1.5 renamed the module ccode to c
+    from sympy.printing.c import C99CodePrinter as CCodePrinter
 
 from .matrix_generator import MatrixGenerator
 from ..utils import wrap_and_indent


### PR DESCRIPTION
- Support Python 2.7 and 3.6-3.7
- [x] Oldest (from 18.04) will not build with Python 3.8.