### PR TITLE
Added a symbolic linear solver option to the CythonODEFunctionGenerator.

### DIFF
--- a/pydy/codegen/c_code.py
+++ b/pydy/codegen/c_code.py
@@ -157,6 +157,11 @@ void evaluate(
 
 
 class _CLUsolveGenerator(CMatrixGenerator):
+    """This is a private undocumented class that supports the
+    ``linear_sys_solver='sympy'`` in CythonMatrixGenerator. It cse's A and b of
+    a linear system Ax=b, then solves the linear system symbolically and cse's
+    the result x. This is a more efficient way to get the symbolic solution of
+    a linear system encoded in generated C code."""
 
     def _generate_cse(self, prefix='pydy_'):
         # NOTE : This assumes the first two items in self.matrices are A and b

--- a/pydy/codegen/cython_code.py
+++ b/pydy/codegen/cython_code.py
@@ -8,6 +8,8 @@ import importlib
 import subprocess
 from collections import defaultdict
 
+import sympy as sm
+
 from .c_code import CMatrixGenerator
 from ..utils import wrap_and_indent
 

--- a/pydy/codegen/cython_code.py
+++ b/pydy/codegen/cython_code.py
@@ -8,8 +8,6 @@ import importlib
 import subprocess
 from collections import defaultdict
 
-import sympy as sm
-
 from .c_code import CMatrixGenerator
 from ..utils import wrap_and_indent
 

--- a/pydy/codegen/ode_function_generators.py
+++ b/pydy/codegen/ode_function_generators.py
@@ -327,7 +327,7 @@ r : dictionary
             self._linear_sys_solver = v
         elif v == 'sympy':
             # dummy function
-            self._solve_linear_system = lambda A, b: b
+            self._solve_linear_system = lambda A, b: np.nan*np.ones_like(b)
             self._linear_sys_solver = v
         else:
             msg = '{} is not a valid solver.'
@@ -551,8 +551,8 @@ r : dictionary
               self.linear_sys_solver=='sympy'):
 
             def base_rhs(*args):
-                M, udot = self.eval_arrays(*args)
-                return udot
+                M, xdot = self.eval_arrays(*args)
+                return xdot
 
             self._base_rhs = base_rhs
 

--- a/pydy/codegen/ode_function_generators.py
+++ b/pydy/codegen/ode_function_generators.py
@@ -659,8 +659,7 @@ class CythonODEFunctionGenerator(ODEFunctionGenerator):
                                   prefix=self._options['prefix'],
                                   cse=self._options['cse'])
         # patch in the special generator
-        g.c_matrix_generator = _CLUsolveGenerator(inputs, outputs[0],
-                                                  outputs[1])
+        g.c_matrix_generator = _CLUsolveGenerator(inputs, outputs)
         return g.compile(tmp_dir=self._options['tmp_dir'],
                          verbose=self._options['verbose'])
 

--- a/pydy/codegen/ode_function_generators.py
+++ b/pydy/codegen/ode_function_generators.py
@@ -655,9 +655,12 @@ class CythonODEFunctionGenerator(ODEFunctionGenerator):
                          verbose=self._options['verbose'])
 
     def _cythonize_symbolic_lusolve(self, outputs, inputs):
+        if not self._options['cse']:
+            msg = 'cse has to be True if using the sympy linear system solver'
+            raise ValueError(msg)
         g = CythonMatrixGenerator(inputs, outputs,
                                   prefix=self._options['prefix'],
-                                  cse=self._options['cse'])
+                                  cse=True)
         # patch in the special generator
         g.c_matrix_generator = _CLUsolveGenerator(inputs, outputs)
         return g.compile(tmp_dir=self._options['tmp_dir'],

--- a/pydy/codegen/tests/test_cython_code.py
+++ b/pydy/codegen/tests/test_cython_code.py
@@ -212,7 +212,7 @@ def test_lusolve_generator():
     generator = CythonMatrixGenerator(arguments, outputs)
     # patch in the special generator
     generator.c_matrix_generator = _CLUsolveGenerator(arguments, outputs)
-    func = generator.compile(tmp_dir='lusolve')
+    func = generator.compile()
 
     # setup the input and output arrays
     args = []

--- a/pydy/codegen/tests/test_cython_code.py
+++ b/pydy/codegen/tests/test_cython_code.py
@@ -6,6 +6,7 @@ import numpy as np
 import sympy as sm
 
 from ...models import multi_mass_spring_damper
+from ..c_code import _CLUsolveGenerator
 from ..cython_code import CythonMatrixGenerator
 
 
@@ -192,3 +193,47 @@ setup(name="boogly_bee",
             filename = self.prefix + suffix
             if os.path.isfile(filename):
                 os.remove(filename)
+
+
+def test_lusolve_generator():
+    """Tests whether the symbolic LUsolve of the cse'd expressions results in
+    the same answer."""
+
+    sys = multi_mass_spring_damper(12, True, True)
+
+    arguments = (sys.constants_symbols, sys.coordinates, sys.speeds,
+                 sys.specifieds_symbols)
+
+    generator = CythonMatrixGenerator(arguments,
+                                      [sys.eom_method.mass_matrix,  # A
+                                       sys.eom_method.forcing])  # b
+    # patch in the special generator
+    generator.c_matrix_generator = _CLUsolveGenerator(
+        arguments, sys.eom_method.mass_matrix, sys.eom_method.forcing)
+    func = generator.compile(tmp_dir='lusolve')
+
+    # setup the input and output arrays
+    args = []
+    subs = {}
+    for argset in arguments:
+        vals = np.random.random(len(argset))
+        args.append(vals)
+        for arg, val in zip(argset, vals):
+            subs[arg] = val
+
+    nr, nc = sys.eom_method.mass_matrix.shape
+    M_vals1 = np.empty(nr*nc, dtype=float)
+    udot_vals = np.empty(nr, dtype=float)
+
+    func(*(args + [M_vals1, udot_vals]))
+
+    gen2 = CythonMatrixGenerator(arguments, [sys.eom_method.mass_matrix,
+                                             sys.eom_method.forcing])
+    func2 = gen2.compile()
+    M_vals = np.empty(nr*nc, dtype=float)
+    b_vals = np.empty(nr, dtype=float)
+    func2(*(args + [M_vals, b_vals]))
+
+    np.testing.assert_allclose(udot_vals,
+                               np.linalg.solve(M_vals.reshape((nr, nc)),
+                                               b_vals))

--- a/pydy/codegen/tests/test_ode_function_generator.py
+++ b/pydy/codegen/tests/test_ode_function_generator.py
@@ -187,6 +187,7 @@ class TestODEFunctionGenerator(object):
                                  self.sys.constants_symbols,
                                  mass_matrix=self.sys.eom_method.mass_matrix_full)
 
+        assert g.linear_sys_solver == 'numpy'
         assert g._solve_linear_system == np.linalg.solve
 
         g = ODEFunctionGenerator(self.sys.eom_method.forcing_full,
@@ -196,6 +197,7 @@ class TestODEFunctionGenerator(object):
                                  mass_matrix=self.sys.eom_method.mass_matrix_full,
                                  linear_sys_solver='numpy')
 
+        assert g.linear_sys_solver == 'numpy'
         assert g._solve_linear_system == np.linalg.solve
 
         g = ODEFunctionGenerator(self.sys.eom_method.forcing_full,
@@ -205,6 +207,7 @@ class TestODEFunctionGenerator(object):
                                  mass_matrix=self.sys.eom_method.mass_matrix_full,
                                  linear_sys_solver='scipy')
 
+        assert g.linear_sys_solver == 'scipy'
         assert g._solve_linear_system == sp.linalg.solve
 
         solver = lambda A, b: np.dot(np.inv(A), b)
@@ -216,6 +219,7 @@ class TestODEFunctionGenerator(object):
                                  mass_matrix=self.sys.eom_method.mass_matrix_full,
                                  linear_sys_solver=solver)
 
+        assert g.linear_sys_solver == solver
         assert g._solve_linear_system == solver
 
     def test_no_constants(self):


### PR DESCRIPTION
This feels a little hacky as is due to the code being a little confusing
with the patched CMatrixGenerator and returning A,x instead of A,b from
Ax=b. But it seems to work and should allow some larger expressions and
matrices to actually compile in a more reasonable time if you want a
symbolically solved system.

Needs another test and some cleanup still.

Fixes #450.

Please edit below based on the type of PR. It is then the duty of reviewers to check off the items as they are completed. If any questions are not relevant to your particular pull request, a reviewer will simply check it off as done.

New Feature
-----------

   - [x] There are no merge conflicts.
   - [x] If there is a related issue, a reference to that issue is in the
     commit message.
   - [x] Unit tests have been added for the new feature.
   - [x] The PR passes tests both locally (run `nosetests`) and on Travis CI.
   - [ ] All public methods and classes have docstrings. (We use the [numpydoc
     format](https://github.com/numpy/numpy/blob/master/doc/HOWTO_DOCUMENT.rst.txt).)
   - [ ] An explanation has been added to the online documentation. (`docs`
     directory)
   - [x] The code follows PEP8 guidelines. (use a linter, e.g.
     [pylint](http://www.pylint.org), to check your code)
   - [ ] The new feature is documented in the [Release
     Notes](https://github.com/pydy/pydy#release-notes).
   - [x] The code is backwards compatible. (All public methods/classes must
     follow deprecation cycles.)
   - [ ] All reviewer comments have been addressed.