### PR TITLE
Swapped order of nonholonomic constraints in Carvallo-Whipple example

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -26,8 +26,8 @@ jobs:
           activate-environment: test-environment
           python-version: ${{ matrix.python-version }}
           channels: conda-forge
-          conda-build-version: 3.21.4
+          miniforge-variant: Mambaforge
       - name: Install basic dependencies
-        run: conda install -q -y cython jupyter_sphinx matplotlib numpy numpydoc pythreejs sphinx sympy scipy
+        run: mamba install -q -y cython jupyter_sphinx matplotlib numpy numpydoc pythreejs sphinx sympy scipy
       - name: Test building documentation
         run: cd docs && make clean && make html && cd ..

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -34,7 +34,7 @@ jobs:
           channels: conda-forge
           miniforge-variant: Mambaforge
       - name: Install basic dependencies
-        run: mamba install -q -y coverage cython matplotlib nose numpy pythreejs "sympy<1.10" scipy
+        run: mamba install -q -y coverage cython matplotlib nose numpy pythreejs 'sympy<1.10' scipy
       - name: Test with nose
         run: nosetests -v --with-coverage --cover-package=pydy
       - name: Test installation of PyDy

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -34,7 +34,9 @@ jobs:
           channels: conda-forge
           miniforge-variant: Mambaforge
       - name: Install basic dependencies
-        run: mamba install -q -y coverage cython matplotlib nose numpy pythreejs 'sympy<1.10' scipy
+        run: |
+          mamba install -q -y coverage cython matplotlib
+          mamba install -q -y nose numpy pythreejs 'sympy<1.10' scipy
       - name: Test with nose
         run: nosetests -v --with-coverage --cover-package=pydy
       - name: Test installation of PyDy

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Install basic dependencies
         run: |
           mamba install -q -y coverage cython matplotlib
-          mamba install -q -y nose numpy pythreejs 'sympy<1.10' scipy
+          mamba install -q -y nose numpy pythreejs sympy=1.8 scipy
       - name: Test with nose
         run: nosetests -v --with-coverage --cover-package=pydy
       - name: Test installation of PyDy

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -34,7 +34,7 @@ jobs:
           channels: conda-forge
           miniforge-variant: Mambaforge
       - name: Install basic dependencies
-        run: mamba install -q -y coverage cython matplotlib nose numpy pythreejs sympy<1.10 scipy
+        run: mamba install -q -y coverage cython matplotlib nose numpy pythreejs "sympy<1.10" scipy
       - name: Test with nose
         run: nosetests -v --with-coverage --cover-package=pydy
       - name: Test installation of PyDy

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -34,7 +34,7 @@ jobs:
           channels: conda-forge
           miniforge-variant: Mambaforge
       - name: Install basic dependencies
-        run: mamba install -q -y coverage cython matplotlib nose numpy pythreejs "sympy<1.10" scipy
+        run: mamba install -q -y coverage cython matplotlib nose numpy pythreejs sympy<1.10 scipy
       - name: Test with nose
         run: nosetests -v --with-coverage --cover-package=pydy
       - name: Test installation of PyDy

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -32,9 +32,9 @@ jobs:
           activate-environment: test-environment
           python-version: ${{ matrix.python-version }}
           channels: conda-forge
-          conda-build-version: 3.21.4
+          miniforge-variant: Mambaforge
       - name: Install basic dependencies
-        run: conda install -q -y coverage cython matplotlib nose numpy pythreejs "sympy<1.10" scipy
+        run: mamba install -q -y coverage cython matplotlib nose numpy pythreejs "sympy<1.10" scipy
       - name: Test with nose
         run: nosetests -v --with-coverage --cover-package=pydy
       - name: Test installation of PyDy

--- a/docs/examples/carvallo-whipple.rst
+++ b/docs/examples/carvallo-whipple.rst
@@ -10,14 +10,8 @@ Carvallo-Whipple Bicycle Model
 
 This example creates a nonlinear model and simulation of the Carvallo-Whipple
 Bicycle Model ([Carvallo1899]_, [Whipple1899]_). This formulation uses the
-conventions described in [Moore2012]_ which are equivalent to and based on the
-models described in [Meijaard2007]_ and [Basu-Mandal2007]_.
-
-.. warning::
-
-   This model does not currently match the [Basu-Mandal2007]_ model to machine
-   precision. Beware if you require that level of precision. See
-   https://github.com/pydy/pydy/pull/122 for discussion on this issue.
+conventions described in [Moore2012]_ which are equivalent to the models
+described in [Meijaard2007]_ and [Basu-Mandal2007]_.
 
 Import the necessary libraries, classes, and functions:
 
@@ -290,11 +284,17 @@ of ``nonholonomic`` above. It is not a nonholonomic constraint, but we include
 it because we can't easy eliminate a dependent generalized coordinate with
 ``nonholonmic``.
 
+.. warning:: The floating point numerical stability of the solution is affected
+   by the order of the nonholonomic constraint expressions in the following
+   list. If ordered ``A['1'],A['2'],A['3']`` stability degrades.
+
 .. jupyter-execute::
 
-   nonholonomic = [fn.vel(N).dot(A['1']),
-                   fn.vel(N).dot(A['2']),
-                   fn.vel(N).dot(A['3'])]
+   nonholonomic = [
+       fn.vel(N).dot(A['1']),
+       fn.vel(N).dot(A['3']),
+       fn.vel(N).dot(A['2']),
+   ]
 
 Inertia
 =======
@@ -453,8 +453,8 @@ Generate a time vector over which the integration will be carried out.
 
 .. jupyter-execute::
 
-    fps = 60  # frames per second
-    duration = 5.0  # seconds
+    fps = 30  # frames per second
+    duration = 6.0  # seconds
     sys.times = np.linspace(0.0, duration, num=int(duration*fps))
 
 The trajectory of the states over time can be found by calling the
@@ -501,8 +501,7 @@ Plot the State Trajectories
    axes[-1].plot(sys.times, np.squeeze(holonomic_vs_time))
    axes[-1].set_ylabel('Holonomic\nconstraint [m]')
    axes[-1].set_xlabel('Time [s]')
-   # Re-enable (was causing a CI build issue (#471))
-   #plt.tight_layout()
+   plt.tight_layout()
 
 Visualizing the System Motion
 =============================


### PR DESCRIPTION
The order of the nonholonomic constraints can affect numerical stability due to the symbolic linear solves internal to KanesMethod. This order ensures that the Basu-Mandal comparison matches to machine precision. It does not remove the divide-by-zero issues for q7=0.0.