### PR TITLE
Make linear_sys_solver='sympy' public.

### DIFF
--- a/pydy/codegen/c_code.py
+++ b/pydy/codegen/c_code.py
@@ -50,7 +50,7 @@ void evaluate(
     def _generate_code_blocks(self):
         """Writes the blocks of code for the C file."""
 
-        # TODO : This could use the super classes method with some tweaks.
+        # TODO : This could use the super class's method with some tweaks.
 
         printer = self._generate_pydy_printer()()
 
@@ -152,12 +152,35 @@ void evaluate(
             f.write(source)
 
 
-class _CLUsolveGenerator(CMatrixGenerator):
+class _CSymbolicLinearSolveGenerator(CMatrixGenerator):
     """This is a private undocumented class that supports the
-    ``linear_sys_solver='sympy'`` in CythonMatrixGenerator. It cse's A and b of
-    a linear system Ax=b, then solves the linear system symbolically and cse's
-    the result x. This is a more efficient way to get the symbolic solution of
-    a linear system encoded in generated C code."""
+    ``linear_sys_solver='sympy:<method>'`` in CythonMatrixGenerator. It cse's A
+    and b of a linear system Ax=b, then solves the linear system symbolically
+    and cse's the result x. This is a more efficient way to get the symbolic
+    solution of a linear system encoded in generated C code.
+
+    Parameters
+    ==========
+    sympy_solver : string
+        Method used to solve the symbolic linear system of the form ``A*x=b``.
+        This should should be a valid method for the SymPy method
+        :meth:`sympy.matrices.matrixbase.MatrixBase.solve`.  The default is
+        ``'LU'`` which corresponds to SymPy's
+        :meth:`sympy.matrices.matrixbase.MatrixBase.LUsolve`. Some other
+        options are: ``'GJ'`` or ``'GE'`` for Gauss-Jordan elimination,
+        ``'QR'`` for :meth:`sympy.matrices.matrixbase.MatrixBase.QRsolve,
+        ``'PINV'`` for :meth:`sympy.matrices.matrixbase.MatrixBase.pinv_solve,
+        ``'CRAMER'`` for
+        :meth:`sympy.matrices.matrixbase.MatrixBase.cramer_solve`, ``'CH'``,
+        :meth:`sympy.matrices.matrixbase.MatrixBase.cholesky_solve`, and
+        ``'LDL'`` for :meth:`sympy.matrices.matrixbase.MatrixBase.LDLsolve`.
+
+    """
+
+    def __init__(self, arguments, matrices, cse=True, verify_arguments=False,
+                 sympy_solver='LU'):
+        self.sympy_solver=sympy_solver
+        super().__init__(arguments, matrices, cse=True, verify_arguments=False)
 
     def _generate_cse(self, prefix='pydy_'):
         # NOTE : This assumes the first two items in self.matrices are A and b
@@ -169,7 +192,7 @@ class _CLUsolveGenerator(CMatrixGenerator):
         A_simp = mats_simp[0]
         b_simp = mats_simp[1]
 
-        x = A_simp.LUsolve(b_simp)
+        x = sm.Matrix.solve(A_simp, b_simp, method=self.sympy_solver)
 
         gen2 = sm.numbered_symbols(prefix, start=len(subexprs1))
         subexprs2, x_simp = sm.cse(x, symbols=gen2)

--- a/pydy/codegen/cython_code.py
+++ b/pydy/codegen/cython_code.py
@@ -89,6 +89,7 @@ setup(name="{prefix}",
         self.arguments = arguments
         self.num_matrices = len(matrices)
         self.num_arguments = len(arguments)
+        # TODO : Should prefix be passed into the CMatrixGenerator?
         self.c_matrix_generator = CMatrixGenerator(arguments, matrices,
                                                    cse=cse)
 

--- a/pydy/codegen/ode_function_generators.py
+++ b/pydy/codegen/ode_function_generators.py
@@ -914,11 +914,14 @@ def generate_ode_function(*args, **kwargs):
 
     generator = kwargs.pop('generator', 'lambdify')
 
-    lin_solver = kwargs['linear_sys_solver']
-
-    if lin_solver.startswith('sympy') and generator != 'cython':
-        msg = f'{generator} does not support the symbolic linear solver.'
-        raise ValueError(msg)
+    try:
+        lin_solver = kwargs['linear_sys_solver']
+    except KeyError:
+        pass
+    else:
+        if lin_solver.startswith('sympy') and generator != 'cython':
+            msg = f'{generator} does not support the symbolic linear solver.'
+            raise ValueError(msg)
 
     try:
         # See if user passed in a custom class.

--- a/pydy/codegen/tests/test_cython_code.py
+++ b/pydy/codegen/tests/test_cython_code.py
@@ -6,7 +6,7 @@ import numpy as np
 import sympy as sm
 
 from ...models import multi_mass_spring_damper
-from ..c_code import _CLUsolveGenerator
+from ..c_code import _CSymbolicLinearSolveGenerator
 from ..cython_code import CythonMatrixGenerator
 
 
@@ -223,7 +223,8 @@ def test_lusolve_generator():
 
     generator = CythonMatrixGenerator(arguments, outputs)
     # patch in the special generator
-    generator.c_matrix_generator = _CLUsolveGenerator(arguments, outputs)
+    generator.c_matrix_generator = _CSymbolicLinearSolveGenerator(arguments,
+                                                                  outputs)
     func = generator.compile()
 
     # setup the input and output arrays


### PR DESCRIPTION
- Adds the linear_sys_solver='sympy` to the docstring of the ode function generators.
- Enables support for different symbolic solvers via linear_sys_solver='sympy:<method`.
- Updates tests to raise errors if symbolic solve is set for generators other than cython.

Fixes #523 