### PR TITLE
Add optional symjit generator.

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -34,7 +34,7 @@ jobs:
           channels: conda-forge
       - name: Install basic dependencies
         run: |
-          conda install -q -y setuptools coverage cython matplotlib packaging pytest pytest-cov numpy pythreejs sympy scipy
+          conda install -q -y setuptools coverage cython matplotlib packaging pytest pytest-cov numpy pythreejs symjit sympy scipy
       - name: Install window dependencies
         if: ${{ matrix.os=='windows-latest' }}
         run: |

--- a/README.rst
+++ b/README.rst
@@ -123,6 +123,7 @@ PyDy has optional dependencies for extended code generation on:
 
 - Cython_ >= 0.29.28
 - Theano_ >= 1.0.5
+- symjit_ >= 2.5.0
 
 and animated visualizations with ``Scene.display_jupyter()`` on:
 
@@ -137,6 +138,7 @@ or interactive animated visualizations with ``Scene.display_ipython()`` on:
 
 .. _Cython: http://cython.org/
 .. _Theano: http://deeplearning.net/software/theano/
+.. _symjit: https://github.com/siravan/symjit
 .. _Jupyter Notebook: https://jupyter-notebook.readthedocs.io
 .. _Jupyter Lab: https://jupyterlab.readthedocs.io
 
@@ -268,8 +270,8 @@ Code Generation (codegen)
 
 This package provides code generation facilities. It generates functions that
 can numerically evaluate the right hand side of the ordinary differential
-equations generated with sympy.physics.mechanics_ with three different
-backends: SymPy's lambdify_, Theano, and Cython.
+equations generated with sympy.physics.mechanics_ with four different
+backends: SymPy's lambdify_, Theano, Cython, and Symjit.
 
 .. _sympy.physics.mechanics: http://docs.sympy.org/latest/modules/physics/mechanics
 .. _lambdify: http://docs.sympy.org/latest/modules/utilities/lambdify.html#sympy.utilities.lambdify.lambdify
@@ -320,7 +322,7 @@ The following installation assumes you have virtualenvwrapper_ in addition to
 virtualenv and all the dependencies needed to build the various packages::
 
    $ mkvirtualenv pydy-dev
-   (pydy-dev)$ pip install numpy scipy cython pytest theano sympy ipython "notebook<5.0" "ipywidgets<5.0" version_information
+   (pydy-dev)$ pip install numpy scipy cython pytest theano symjit sympy ipython "notebook<5.0" "ipywidgets<5.0" version_information
    (pydy-dev)$ pip install matplotlib # make sure to do this after numpy
    (pydy-dev)$ git clone git@github.com:pydy/pydy.git
    (pydy-dev)$ cd pydy
@@ -330,7 +332,7 @@ virtualenv and all the dependencies needed to build the various packages::
 
 Or with conda_::
 
-   $ conda create -c pydy -n pydy-dev setuptools numpy scipy ipython "notebook<5.0" "ipywidgets<5.0" cython pytest theano sympy matplotlib version_information
+   $ conda create -c pydy -n pydy-dev setuptools numpy scipy ipython "notebook<5.0" "ipywidgets<5.0" cython pytest theano symjit sympy matplotlib version_information
    $ source activate pydy-dev
    (pydy-dev)$ git clone git@github.com:pydy/pydy.git
    (pydy-dev)$ cd pydy

--- a/bin/benchmark_pydy_code_gen.py
+++ b/bin/benchmark_pydy_code_gen.py
@@ -18,7 +18,7 @@ def run_benchmark(max_num_links, num_time_steps=1000, duration=10.0):
     for each n up to the max number provided and generates a plot of the
     results."""
 
-    methods = ['lambdify', 'cython', 'theano']
+    methods = ['lambdify', 'cython', 'theano', 'symjit']
 
     link_numbers = range(1, max_num_links + 1)
 

--- a/bin/benchmark_pydy_code_gen.py
+++ b/bin/benchmark_pydy_code_gen.py
@@ -104,7 +104,7 @@ def run_benchmark(max_num_links, num_time_steps=1000, duration=10.0):
 
     # plot the results
     fig, ax = plt.subplots(4, 1, sharex=True, layout='constrained',
-                           figsize=(5, 6))
+                           figsize=(6, 6))
 
     ax[0].plot(link_numbers, derivation_times)
     ax[0].set_title('Symbolic Derivation Time')

--- a/bin/benchmark_pydy_code_gen.py
+++ b/bin/benchmark_pydy_code_gen.py
@@ -2,8 +2,10 @@
 
 # standard library
 import time
+import timeit
 
 # external libraries
+import numpy as np
 from numpy import hstack, ones, pi, linspace, array, zeros, zeros_like, nan
 from pydy.models import n_link_pendulum_on_cart
 from sympy import symbols
@@ -23,6 +25,7 @@ def run_benchmark(max_num_links, num_time_steps=1000, duration=10.0):
     link_numbers = range(1, max_num_links + 1)
 
     derivation_times = zeros(len(link_numbers))
+    rhs_times = zeros((max_num_links, len(methods)))
     integration_times = zeros((max_num_links, len(methods)))
     code_generation_times = zeros_like(integration_times)
 
@@ -72,7 +75,7 @@ def run_benchmark(max_num_links, num_time_steps=1000, duration=10.0):
             print('-' * len(subtitle))
             start = time.time()
             try:
-                sys.generate_ode_function(generator=method, cse=True)
+                rhs = sys.generate_ode_function(generator=method, cse=True)
             # ImportError: Theano or Cython not installed
             # AttributeError: Theano doesn't work with new NumPy versions
             except (ImportError, AttributeError):
@@ -84,6 +87,13 @@ def run_benchmark(max_num_links, num_time_steps=1000, duration=10.0):
                 print('The code generation took {:1.5f} seconds.'.format(
                     code_generation_times[j, k]))
 
+                p_vals = np.array(parameter_vals)
+                rhs_time = timeit.timeit(lambda: rhs(x0, 0.1, p_vals),
+                                         number=1000)
+                rhs_times[j, k] = rhs_time
+                print('rhs() evaluation took {:1.5f} seconds.'.format(
+                    rhs_time))
+
                 start = time.time()
                 sys.integrate()
                 integration_times[j, k] = time.time() - start
@@ -93,7 +103,8 @@ def run_benchmark(max_num_links, num_time_steps=1000, duration=10.0):
         del sys
 
     # plot the results
-    fig, ax = plt.subplots(3, 1, sharex=True, layout='constrained')
+    fig, ax = plt.subplots(4, 1, sharex=True, layout='constrained',
+                           figsize=(5, 6))
 
     ax[0].plot(link_numbers, derivation_times)
     ax[0].set_title('Symbolic Derivation Time')
@@ -103,10 +114,15 @@ def run_benchmark(max_num_links, num_time_steps=1000, duration=10.0):
     ax[1].set_title('Code Generation Time')
     ax[1].legend(methods, loc=2)
 
-    ax[2].plot(link_numbers, integration_times)
+    ax[2].plot(link_numbers, rhs_times)
     ax[2].set_yscale('log')
-    ax[2].set_title('Integration Time')
+    ax[2].set_title('ODE Evaluation Time')
     ax[2].legend(methods, loc=2)
+
+    ax[3].plot(link_numbers, integration_times)
+    ax[3].set_yscale('log')
+    ax[3].set_title('Integration Time')
+    ax[3].legend(methods, loc=2)
 
     for a in ax.flatten():
         a.set_ylabel('Time [s]')

--- a/conda/pydy-dev-env.yml
+++ b/conda/pydy-dev-env.yml
@@ -25,4 +25,5 @@ dependencies:
   - python=3.*
   - pythreejs
   - sphinx
+  - symjit
   - sympy

--- a/pydy/codegen/ode_function_generators.py
+++ b/pydy/codegen/ode_function_generators.py
@@ -986,23 +986,24 @@ class SymjitODEFunctionGenerator(ODEFunctionGenerator):
 
         f = self._symjitify(outputs)
 
-        k_dim = len(self.inputs[0])
-        m_dim = len(self.inputs[0]) + len(self.inputs[1])
+        m_dim = len(self.inputs[1])
 
         if self.specifieds is None:
             def convert_symjit_output(q, u, p):
                 all_vals = np.asarray(f(*np.hstack((q, u, p))))
                 m_vals = all_vals[:m_dim*m_dim].reshape(m_dim, m_dim)
-                f_vals = all_vals[m_dim*m_dim:m_dim*m_dim + k_dim]
-                k_vals = all_vals[m_dim*m_dim + k_dim:]
+                f_vals = all_vals[m_dim*m_dim:m_dim*m_dim + m_dim]
+                k_vals = all_vals[m_dim*m_dim + m_dim:]
                 return m_vals, f_vals, k_vals
         else:
             def convert_symjit_output(q, u, r, p):
                 all_vals = np.asarray(f(*np.hstack((q, u, r, p))))
                 m_vals = all_vals[:m_dim*m_dim].reshape(m_dim, m_dim)
-                f_vals = all_vals[m_dim*m_dim:m_dim*m_dim + k_dim]
-                k_vals = all_vals[m_dim*m_dim + k_dim:]
+                f_vals = all_vals[m_dim*m_dim:m_dim*m_dim + m_dim]
+                k_vals = all_vals[m_dim*m_dim + m_dim:]
                 return m_vals, f_vals, k_vals
+
+        self.eval_arrays = convert_symjit_output
 
 
 def generate_ode_function(*args, **kwargs):
@@ -1047,7 +1048,7 @@ _extra_parameters_doc = \
 """\
         generator : string or and ODEFunctionGenerator, optional
             The method used for generating the numeric right hand side. The
-            string options are {'lambdify'|'theano'|'cython'} with
+            string options are {'lambdify'|'theano'|'cython'|'symjit'} with
             'lambdify' being the default. You can also pass in a custom
             subclass of ODEFunctionGenerator.
 

--- a/pydy/codegen/ode_function_generators.py
+++ b/pydy/codegen/ode_function_generators.py
@@ -13,7 +13,7 @@ import sympy.physics.mechanics as me
 from sympy.core.function import UndefinedFunction, Derivative
 Cython = sm.external.import_module('Cython')
 theano = sm.external.import_module('theano')
-symjit = sm.external.import_module('symjit')
+symjit = sm.external.import_module('symjit', min_module_version='2.5.0')
 if theano:
     from sympy.printing.theanocode import theano_function
 if symjit:

--- a/pydy/codegen/ode_function_generators.py
+++ b/pydy/codegen/ode_function_generators.py
@@ -4,6 +4,7 @@ import sys
 from collections.abc import Sequence
 from itertools import chain
 import logging
+from importlib import metadata
 
 import numpy as np
 import numpy.linalg
@@ -11,9 +12,10 @@ import scipy.linalg
 import sympy as sm
 import sympy.physics.mechanics as me
 from sympy.core.function import UndefinedFunction, Derivative
+from packaging.version import parse as parse_version
 Cython = sm.external.import_module('Cython')
 theano = sm.external.import_module('theano')
-symjit = sm.external.import_module('symjit', min_module_version='2.5.0')
+symjit = sm.external.import_module('symjit')
 if theano:
     from sympy.printing.theanocode import theano_function
 if symjit:
@@ -906,6 +908,10 @@ class SymjitODEFunctionGenerator(ODEFunctionGenerator):
 
         if symjit is None:
             raise ImportError('Symjit must be installed to use this class.')
+
+        symjit_version = metadata.version('symjit')
+        if parse_version(symjit_version) < parse_version('2.5.0'):
+            raise ImportError('Symjit >= 2.5.0 is required.')
 
         self._options = {'cse': True}
 

--- a/pydy/codegen/ode_function_generators.py
+++ b/pydy/codegen/ode_function_generators.py
@@ -904,6 +904,9 @@ class SymjitODEFunctionGenerator(ODEFunctionGenerator):
 
     def __init__(self, *args, **kwargs):
 
+        if symjit is None:
+            raise ImportError('Symjit must be installed to use this class.')
+
         self._options = {'cse': True}
 
         for k, v in self._options.items():
@@ -947,10 +950,10 @@ class SymjitODEFunctionGenerator(ODEFunctionGenerator):
         # NOTE : symjit outputs a list of floats, not a NumPy array of floats.
         if self.specifieds is None:
             def wrapper(q, u, p):
-                return np.asarray(f(*np.hstack((q, u, p))))
+                return np.asarray(f.apply(np.hstack((q, u, p))))
         else:
             def wrapper(q, u, r, p):
-                return np.asarray(f(*np.hstack((q, u, r, p))))
+                return np.asarray(f.apply(np.hstack((q, u, r, p))))
 
         self.eval_arrays = wrapper
 
@@ -965,13 +968,13 @@ class SymjitODEFunctionGenerator(ODEFunctionGenerator):
 
         if self.specifieds is None:
             def wrapper(q, u, p):
-                all_vals = np.asarray(f(*np.hstack((q, u, p))))
+                all_vals = np.asarray(f.apply(np.hstack((q, u, p))))
                 m_vals = all_vals[:m_dim*m_dim].reshape(m_dim, m_dim)
                 f_vals = all_vals[m_dim*m_dim:]
                 return m_vals, f_vals
         else:
             def wrapper(q, u, r, p):
-                all_vals = np.asarray(f(*np.hstack((q, u, r, p))))
+                all_vals = np.asarray(f.apply(np.hstack((q, u, r, p))))
                 m_vals = all_vals[:m_dim*m_dim].reshape(m_dim, m_dim)
                 f_vals = all_vals[m_dim*m_dim:]
                 return m_vals, f_vals
@@ -990,14 +993,14 @@ class SymjitODEFunctionGenerator(ODEFunctionGenerator):
 
         if self.specifieds is None:
             def convert_symjit_output(q, u, p):
-                all_vals = np.asarray(f(*np.hstack((q, u, p))))
+                all_vals = np.asarray(f.apply(np.hstack((q, u, p))))
                 m_vals = all_vals[:m_dim*m_dim].reshape(m_dim, m_dim)
                 f_vals = all_vals[m_dim*m_dim:m_dim*m_dim + m_dim]
                 k_vals = all_vals[m_dim*m_dim + m_dim:]
                 return m_vals, f_vals, k_vals
         else:
             def convert_symjit_output(q, u, r, p):
-                all_vals = np.asarray(f(*np.hstack((q, u, r, p))))
+                all_vals = np.asarray(f.apply(np.hstack((q, u, r, p))))
                 m_vals = all_vals[:m_dim*m_dim].reshape(m_dim, m_dim)
                 f_vals = all_vals[m_dim*m_dim:m_dim*m_dim + m_dim]
                 k_vals = all_vals[m_dim*m_dim + m_dim:]

--- a/pydy/codegen/tests/test_ode_function_generator.py
+++ b/pydy/codegen/tests/test_ode_function_generator.py
@@ -11,12 +11,14 @@ import pytest
 
 Cython = sm.external.import_module('Cython')
 theano = sm.external.import_module('theano')
+symjit = sm.external.import_module('symjit')
 
 from ... import models
 from ..ode_function_generators import (ODEFunctionGenerator,
                                        LambdifyODEFunctionGenerator,
                                        CythonODEFunctionGenerator,
-                                       TheanoODEFunctionGenerator)
+                                       TheanoODEFunctionGenerator,
+                                       SymjitODEFunctionGenerator)
 
 from ...utils import PyDyImportWarning
 
@@ -294,6 +296,12 @@ class TestODEFunctionGeneratorSubclasses(object):
         ode_function_subclasses.append(TheanoODEFunctionGenerator)
     else:
         warnings.warn("Theano was not found so the related tests are being"
+                      " skipped.", PyDyImportWarning)
+
+    if symjit:
+        ode_function_subclasses.append(SymjitODEFunctionGenerator)
+    else:
+        warnings.warn("Symjit was not found so the related tests are being"
                       " skipped.", PyDyImportWarning)
 
     def setup_method(self):

--- a/pydy/codegen/tests/test_ode_function_generator.py
+++ b/pydy/codegen/tests/test_ode_function_generator.py
@@ -304,7 +304,7 @@ class TestODEFunctionGeneratorSubclasses(object):
         symjit_version = metadata.version('symjit')
     else:
         symjit_version = '0.0.1'
-    if parse_version(symjit_version) < parse_version('2.5.0'):
+    if parse_version(symjit_version) >= parse_version('2.5.0'):
         ode_function_subclasses.append(SymjitODEFunctionGenerator)
     else:
         warnings.warn("Symjit was not found so the related tests are being"

--- a/pydy/codegen/tests/test_ode_function_generator.py
+++ b/pydy/codegen/tests/test_ode_function_generator.py
@@ -2,12 +2,14 @@
 
 from random import choice
 import warnings
+from importlib import metadata
 
 import numpy as np
 import scipy as sp
 import sympy as sm
 from pydy.codegen.ode_function_generators import generate_ode_function
 import pytest
+from packaging.version import parse as parse_version
 
 Cython = sm.external.import_module('Cython')
 theano = sm.external.import_module('theano')
@@ -299,6 +301,10 @@ class TestODEFunctionGeneratorSubclasses(object):
                       " skipped.", PyDyImportWarning)
 
     if symjit:
+        symjit_version = metadata.version('symjit')
+    else:
+        symjit_version = '0.0.1'
+    if parse_version(symjit_version) < parse_version('2.5.0'):
         ode_function_subclasses.append(SymjitODEFunctionGenerator)
     else:
         warnings.warn("Symjit was not found so the related tests are being"

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,8 @@ extras_require = {
     ],
     'codegen': [
         'Cython>=0.29.28',
-        'Theano>=1.0.5'
+        'Theano>=1.0.5',
+        'symjit>=2.5.0',
     ],
     'examples': [
         'matplotlib>=3.5.1',


### PR DESCRIPTION
This adds a new ODEFunctionGenerator that uses symjit as sympy->numeric code generator and compiler. symjit does not support iterable of iterables as function arguments and it can only output flat arrays, so a fair amount of input/output conversion is needed that slows down both the code generation and the numerical evaluation. Replacing symbols in the equations of motion does not seem to slow symjit's code generation which is clearly very fast but the numeric manipulation and type conversion does slow down the evaluation. If symjit can manage some things faster internally to manage similar inputs that lambdify accepts, then symjit may have equal evaluation speed to the Cython generation code and generate extremely faster.

Here is the benchmark run with 16 pendulum links, 100 integration steps, and 2 second duration.

```
bin/benchmark_pydy_code_gen.py 16 100 2
```

<img width="640" height="480" alt="benchmark-results" src="https://github.com/user-attachments/assets/8e613d43-9510-42ca-b747-5046c073ee4d" />

This needs a bit more tidying and management of the optional dependency before merging.
