### PR TITLE
Add Baumgarte's stabilization to bicycle model.

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -27,6 +27,6 @@ jobs:
           python-version: ${{ matrix.python-version }}
           channels: conda-forge
       - name: Install basic dependencies
-        run: conda install -q -y cython jupyter_sphinx "jupyter_core<5" matplotlib numpy numpydoc pythreejs setuptools "sphinx<7" symjit sympy scipy
+        run: conda install -q -y "cython=0.29.*" "jupyter_sphinx=0.3.*" "matplotlib-base=3.5.*" "numpy=1.21.*" "numpydoc=1.2.*" pythreejs "setuptools=44.1.*" "sphinx=4.3.*" symjit "sympy=1.9.*" "scipy=1.8.*"
       - name: Test building documentation
         run: cd docs && make clean && make html && cd ..

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -27,6 +27,6 @@ jobs:
           python-version: ${{ matrix.python-version }}
           channels: conda-forge
       - name: Install basic dependencies
-        run: conda install -q -y cython jupyter_sphinx matplotlib numpy numpydoc pythreejs setuptools "sphinx<7" symjit sympy scipy
+        run: conda install -q -y cython jupyter_sphinx "jupyter_core<5" matplotlib numpy numpydoc pythreejs setuptools "sphinx<7" symjit sympy scipy
       - name: Test building documentation
         run: cd docs && make clean && make html && cd ..

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -27,6 +27,6 @@ jobs:
           python-version: ${{ matrix.python-version }}
           channels: conda-forge
       - name: Install basic dependencies
-        run: conda install -q -y "cython=0.29.*" "jupyter_sphinx=0.3.*" "matplotlib-base=3.5.*" "numpy=1.21.*" "numpydoc=1.2.*" pythreejs "setuptools=44.1.*" "sphinx=4.3.*" symjit "sympy=1.9.*" "scipy=1.8.*"
+        run: conda install -q -y "cython=0.29.*" "jupyter_sphinx=0.3.*" "matplotlib-base=3.5.*" "numpy=1.21.*" "numpydoc=1.2.*" pythreejs setuptools "sphinx=4.3.*" symjit "sympy=1.9.*" "scipy=1.8.*"
       - name: Test building documentation
         run: cd docs && make clean && make html && cd ..

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -27,6 +27,6 @@ jobs:
           python-version: ${{ matrix.python-version }}
           channels: conda-forge
       - name: Install basic dependencies
-        run: conda install -q -y "cython=0.29.*" "jupyter_sphinx=0.3.*" jupyter "matplotlib-base=3.5.*" "numpy=1.21.*" "numpydoc=1.2.*" pythreejs setuptools "sphinx=4.3.*" symjit "sympy=1.9.*" "scipy=1.8.*"
+        run: conda install -q -y "cython=0.29.*" "jupyter_sphinx=0.3.*" "jupyter<1.1" "ipwidgets<8" "matplotlib-base=3.5.*" "numpy=1.21.*" "numpydoc=1.2.*" pythreejs setuptools "sphinx=4.3.*" symjit "sympy=1.9.*" "scipy=1.8.*"
       - name: Test building documentation
         run: cd docs && make clean && make html && cd ..

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -27,6 +27,6 @@ jobs:
           python-version: ${{ matrix.python-version }}
           channels: conda-forge
       - name: Install basic dependencies
-        run: conda install -q -y "cython=0.29.*" "jupyter_sphinx=0.3.*" "matplotlib-base=3.5.*" "numpy=1.21.*" "numpydoc=1.2.*" pythreejs setuptools "sphinx=4.3.*" symjit "sympy=1.9.*" "scipy=1.8.*"
+        run: conda install -q -y "cython=0.29.*" "jupyter_sphinx=0.3.*" jupyter "matplotlib-base=3.5.*" "numpy=1.21.*" "numpydoc=1.2.*" pythreejs setuptools "sphinx=4.3.*" symjit "sympy=1.9.*" "scipy=1.8.*"
       - name: Test building documentation
         run: cd docs && make clean && make html && cd ..

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -27,6 +27,6 @@ jobs:
           python-version: ${{ matrix.python-version }}
           channels: conda-forge
       - name: Install basic dependencies
-        run: conda install -q -y "cython=0.29.*" "jupyter_sphinx=0.3.*" "jupyter<1.1" "ipwidgets<8" "matplotlib-base=3.5.*" "numpy=1.21.*" "numpydoc=1.2.*" pythreejs setuptools "sphinx=4.3.*" symjit "sympy=1.9.*" "scipy=1.8.*"
+        run: conda install -q -y "cython=0.29.*" "jupyter_sphinx=0.3.*" "jupyter<1.1" "ipywidgets<8" "matplotlib-base=3.5.*" "numpy=1.21.*" "numpydoc=1.2.*" pythreejs setuptools "sphinx=4.3.*" symjit "sympy=1.9.*" "scipy=1.8.*"
       - name: Test building documentation
         run: cd docs && make clean && make html && cd ..

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -27,6 +27,6 @@ jobs:
           python-version: ${{ matrix.python-version }}
           channels: conda-forge
       - name: Install basic dependencies
-        run: conda install -q -y cython jupyter_sphinx matplotlib numpy numpydoc pythreejs setuptools sphinx symjit sympy scipy
+        run: conda install -q -y cython jupyter_sphinx matplotlib numpy numpydoc pythreejs setuptools "sphinx<7" symjit sympy scipy
       - name: Test building documentation
         run: cd docs && make clean && make html && cd ..

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,9 +6,9 @@ Release Notes
 ==========
 
 - The symbolic linear system solver option is now public and supports selecting
-  optional symbolic linear system solvers. [PR `525`_]
-- Removed more tests and code paths for unsupported SymPy < 1.9. [PRs `522`_,
-  `524`_, `527`_]
+  optional symbolic linear system solvers. [PR `#525`_]
+- Removed more tests and code paths for unsupported SymPy < 1.9. [PRs `#522`_,
+  `#524`_, `#527`_]
 - Moved viz API to a sublevel in the docs instead of top level.
 
 .. _#522: https://github.com/pydy/pydy/pull/522

--- a/docs/examples/3d-n-body-pendulum.rst
+++ b/docs/examples/3d-n-body-pendulum.rst
@@ -185,15 +185,15 @@ integration.  - of course I do not know for sure.
     qL = q1 + u1
     pL = [m, m1, g, r, l, iXX, iYY, iZZ, reibung, k]
 
-    MM_lam = sm.lambdify(qL + pL, MM, cse=True)
-    force_lam = sm.lambdify(qL + pL, force, cse=True)
+    MM_lam = sm.lambdify(qL + pL, MM)
+    force_lam = sm.lambdify(qL + pL, force)
 
-    pot_lam = sm.lambdify(qL + pL, pot_energie, cse=True)
-    kin_lam = sm.lambdify(qL + pL, kin_energie, cse=True)
-    spring_lam = sm.lambdify(qL + pL, spring_energie, cse=True)
+    pot_lam = sm.lambdify(qL + pL, pot_energie)
+    kin_lam = sm.lambdify(qL + pL, kin_energie)
+    spring_lam = sm.lambdify(qL + pL, spring_energie)
 
-    Dmc_loc_lam = sm.lambdify(qL + pL, Dmc_loc, cse=True)
-    punkt_loc_lam = sm.lambdify(qL + pL, punkt_loc, cse=True)
+    Dmc_loc_lam = sm.lambdify(qL + pL, Dmc_loc)
+    punkt_loc_lam = sm.lambdify(qL + pL, punkt_loc)
 
     print('it took {:.3f} sec to set up Kanes equations'.format(time.time() - start))
 
@@ -304,7 +304,7 @@ rotation is fully correct, just played around until it 'looked' reasonable.
 
     winkel = sm.symbols('winkel')
     Rotation1 = sm.Matrix([[sm.cos(winkel), -sm.sin(winkel), 0], [sm.sin(winkel), sm.cos(winkel), 0], [0., 0., 1]])
-    Rot_lam = sm.lambdify(winkel, Rotation1.T, cse=True)
+    Rot_lam = sm.lambdify(winkel, Rotation1.T)
     Rotation = Rot_lam(np.pi/2.)
 
     TC_store = []
@@ -318,17 +318,17 @@ rotation is fully correct, just played around until it 'looked' reasonable.
         TC = sm.eye(4)
         TC[:3, :3] = (A[i].dcm(N)) * Rotation
         TC = TC.reshape(16, 1)
-        TC_lam = sm.lambdify(qL + pL, TC, cse=True)
+        TC_lam = sm.lambdify(qL + pL, TC)
 
         TR = sm.eye(4)
         TR[:3, :3] = (A[i].dcm(N)) * Rotation
         TR = TR.reshape(16, 1)
-        TR_lam = sm.lambdify(qL + pL, TR, cse=True)
+        TR_lam = sm.lambdify(qL + pL, TR)
 
         TP = sm.eye(4)
         TP[:3, :3] = (A[i].dcm(N)) * Rotation
         TP = TP.reshape(16, 1)
-        TP_lam = sm.lambdify(qL + pL, TP, cse=True)
+        TP_lam = sm.lambdify(qL + pL, TP)
 
 
     # store the information about the body, expressed in TAc for every time step.

--- a/docs/examples/carvallo-whipple.rst
+++ b/docs/examples/carvallo-whipple.rst
@@ -349,13 +349,9 @@ with ones that append the Baumgarte force to the holonomic constraint.
 
 .. jupyter-execute::
 
-   q = (q1, q2, q3, q4, q5, q6, q7, q8)
-   u = (u1, u2, u3, u4, u5, u6, u7, u8)
-   qdd_repl = {qi.diff(t, 2): ui.diff(t) for qi, ui in zip(q, u)}
-   qd_repl = {qi.diff(t): ui for qi, ui in zip(q, u)}
-   acc_con = [c.diff(t).xreplace(qdd_repl).xreplace(qd_repl) for c in nonholonomic]
+   acc_constraints = [c.diff(t) for c in nonholonomic]
    alpha = sm.symbols('alpha')
-   acc_con[1] = acc_con[1] + 2*alpha*nonholonomic[1] + alpha**2*holonomic
+   acc_constraints[1] += 2*alpha*nonholonomic[1] + alpha**2*holonomic
 
 Kane's Method
 =============
@@ -370,7 +366,7 @@ Kane's Method
                           configuration_constraints=[holonomic],
                           u_dependent=[u3, u5, u8],  # yaw rate, pitch rate, front wheel rate
                           velocity_constraints=nonholonomic,
-                          acceleration_constraints=acc_con)
+                          acceleration_constraints=acc_constraints)
 
    fr, frstar = kane.kanes_equations(bodies, loads)
 

--- a/docs/examples/carvallo-whipple.rst
+++ b/docs/examples/carvallo-whipple.rst
@@ -341,12 +341,18 @@ Loads
 Baumgarte's Stabilization
 =========================
 
+The holonomic constraint, the single algebraic equation in the equatiosn of
+motion, will drift during numerical integration. Baumgarte's stabalization
+technique can be used to limit the drift [Baumgarte1972]_. This requires
+manually setting the acceleration level constraint equations in ``KanesMethod``
+with ones that append the Baumgarte force to the holonomic constraint.
+
 .. jupyter-execute::
 
    q = (q1, q2, q3, q4, q5, q6, q7, q8)
    u = (u1, u2, u3, u4, u5, u6, u7, u8)
-   qd_repl = {qi.diff(t): ui for qi, ui in zip(q, u)}
    qdd_repl = {qi.diff(t, 2): ui.diff(t) for qi, ui in zip(q, u)}
+   qd_repl = {qi.diff(t): ui for qi, ui in zip(q, u)}
    acc_con = [c.diff(t).xreplace(qdd_repl).xreplace(qd_repl) for c in nonholonomic]
    alpha = sm.symbols('alpha')
    acc_con[1] = acc_con[1] + 2*alpha*nonholonomic[1] + alpha**2*holonomic
@@ -431,14 +437,14 @@ be dependent. Below, the pitch angle is taken as dependent and solved for using
 .. jupyter-execute::
 
     eval_holonomic = sm.lambdify((q5, q4, q7, d1, d2, d3, rf, rr), holonomic)
-    initial_pitch_angle = float(fsolve(eval_holonomic, 0.0,
-                                       args=(0.0,  # q4
-                                             1e-8,  # q7
-                                             sys.constants[d1],
-                                             sys.constants[d2],
-                                             sys.constants[d3],
-                                             sys.constants[rf],
-                                             sys.constants[rr])))
+    initial_pitch_angle = fsolve(eval_holonomic, 0.0,
+                                 args=(0.0,  # q4
+                                       1e-8,  # q7
+                                       sys.constants[d1],
+                                       sys.constants[d2],
+                                       sys.constants[d3],
+                                       sys.constants[rf],
+                                       sys.constants[rr]))[0]
     np.rad2deg(initial_pitch_angle)
 
 Set all of the initial conditions.
@@ -469,19 +475,12 @@ Generate a time vector over which the integration will be carried out.
 .. jupyter-execute::
 
     fps = 30  # frames per second
-    duration = 6.0  # seconds
+    duration = 10.0  # seconds
     sys.times = np.linspace(0.0, duration, num=int(duration*fps))
 
 The trajectory of the states over time can be found by calling the
 ``.integrate()`` method. But due to the complexity of the equations of motion
 it is helpful to use the ``cython`` generator for faster numerical evaluation.
-
-.. warning::
-
-   The holonomic constraint equation is not explicitly enforced, as PyDy does
-   not yet support integration of differential algebraic equations (DAEs) yet.
-   The solution will drift from the true solution over time with magnitudes
-   dependent on the intiial conditions and constants values.
 
 .. jupyter-execute::
 
@@ -581,6 +580,9 @@ References
    Bicycle." Quarterly Journal of Pure and Applied Mathematics 30 (1899): 312–48.
 .. [Carvallo1899] Carvallo, E. Théorie Du Mouvement Du Monocycle et de La
    Bicyclette. Paris, France: Gauthier- Villars, 1899.
+.. [Baumgarte1972] Baumgarte, J. (1972). Stabilization of Constraints and
+   Integrals of Motion in Dynamical  Systems. Computer Methods in Applied
+   Mechanics and Engineering, 1, 1–16.
 .. [Moore2012] Moore, Jason K. "Human Control of a Bicycle." Doctor of
    Philosophy, University of California, 2012.
    http://moorepants.github.io/dissertation.

--- a/docs/examples/carvallo-whipple.rst
+++ b/docs/examples/carvallo-whipple.rst
@@ -338,6 +338,19 @@ Loads
 
    loads = [Fco, Fdo, Feo, Ffo, Tc, Td, Te]
 
+Baumgarte's Stabilization
+=========================
+
+.. jupyter-execute::
+
+   q = (q1, q2, q3, q4, q5, q6, q7, q8)
+   u = (u1, u2, u3, u4, u5, u6, u7, u8)
+   qd_repl = {qi.diff(t): ui for qi, ui in zip(q, u)}
+   qdd_repl = {qi.diff(t, 2): ui.diff(t) for qi, ui in zip(q, u)}
+   acc_con = [c.diff(t).xreplace(qdd_repl).xreplace(qd_repl) for c in nonholonomic]
+   alpha = sm.symbols('alpha')
+   acc_con[1] = acc_con[1] + 2*alpha*nonholonomic[1] + alpha**2*holonomic
+
 Kane's Method
 =============
 
@@ -350,7 +363,8 @@ Kane's Method
                           q_dependent=[q5],  # pitch angle
                           configuration_constraints=[holonomic],
                           u_dependent=[u3, u5, u8],  # yaw rate, pitch rate, front wheel rate
-                          velocity_constraints=nonholonomic)
+                          velocity_constraints=nonholonomic,
+                          acceleration_constraints=acc_con)
 
    fr, frstar = kane.kanes_equations(bodies, loads)
 
@@ -397,7 +411,8 @@ states in the form of a dict. The are the benchmark values used in
        ie22: 0.06,
        ie31: 0.009119225261946298,
        ie33: 0.007586622998470264,
-       g: 9.81
+       g: 9.81,
+       alpha: 10.0,
     }
 
 Setup the initial conditions such that the bicycle is traveling at some forward

--- a/docs/examples/carvallo-whipple.rst
+++ b/docs/examples/carvallo-whipple.rst
@@ -341,11 +341,11 @@ Loads
 Baumgarte's Stabilization
 =========================
 
-The holonomic constraint, the single algebraic equation in the equatiosn of
-motion, will drift during numerical integration. Baumgarte's stabalization
+The holonomic constraint, the single algebraic equation in the equations of
+motion, will drift during numerical integration. Baumgarte's stabilization
 technique can be used to limit the drift [Baumgarte1972]_. This requires
 manually setting the acceleration level constraint equations in ``KanesMethod``
-with ones that append the Baumgarte force to the holonomic constraint.
+with ones that append the Baumgarte "force" to the holonomic constraint.
 
 .. jupyter-execute::
 
@@ -579,9 +579,6 @@ References
 .. [Baumgarte1972] Baumgarte, J. (1972). Stabilization of Constraints and
    Integrals of Motion in Dynamical  Systems. Computer Methods in Applied
    Mechanics and Engineering, 1, 1–16.
-.. [Moore2012] Moore, Jason K. "Human Control of a Bicycle." Doctor of
-   Philosophy, University of California, 2012.
-   http://moorepants.github.io/dissertation.
 .. [Meijaard2007] Meijaard, J. P., Jim M. Papadopoulos, Andy Ruina, and A. L.
    Schwab. "Linearized Dynamics Equations for the Balance and Steer of a
    Bicycle: A Benchmark and Review." Proceedings of the Royal Society A:
@@ -592,3 +589,6 @@ References
    Proceedings of the Royal Society A: Mathematical, Physical and Engineering
    Sciences 463, no. 2084 (August 8, 2007): 1983–2003.
    https://doi.org/10.1098/rspa.2007.1849.
+.. [Moore2012] Moore, Jason K. "Human Control of a Bicycle." Doctor of
+   Philosophy, University of California, 2012.
+   http://moorepants.github.io/dissertation.


### PR DESCRIPTION
This will need some tidying but I read Baumgarte's original paper and realized it was rather easy to include his stabilization technique for constraints. You simply add a spring and damper to the acceleration level constraints for any holonomic constraints in which the spring displacement is the residual of the holonomic constraint.

If I simulate the bicycle example for 20 seconds with no stabilization this is the holonomic constraint residual:

<img width="781" height="138" alt="image" src="https://github.com/user-attachments/assets/8763a026-ba44-4fa5-9fff-b9f0da2c9e08" />

And with alpha = 10:

<img width="778" height="127" alt="image" src="https://github.com/user-attachments/assets/3f2d65df-8450-4cad-9280-9d8c499b0f78" />