### PR TITLE
Add support for output equations to ODEFunctionGenerator

### DIFF
--- a/docs/codegen.rst
+++ b/docs/codegen.rst
@@ -87,8 +87,7 @@ classes:
 
 .. code:: pycon
 
-   >>> from numpy import array
-   >>> from pydy.models import multi_mass_spring_damper
+   >>> import numpy as np
    >>> from pydy.codegen.ode_function_generators import generate_ode_function
    >>> sys = multi_mass_spring_damper()
    >>> sym_rhs = sys.eom_method.rhs()
@@ -96,7 +95,7 @@ classes:
    >>> u = sys.speeds
    >>> p = sys.constants_symbols
    >>> rhs = generate_ode_function(sym_rhs, q, u, p)
-   >>> rhs(array([1.0, 2.0]), 0.0, array([1.0, 2.0, 3.0]))
+   >>> rhs(np.array([1.0, 2.0]), 0.0, np.array([1.0, 2.0, 3.0]))
    array([ 2., -7.])
 
 Other backends can be used by passing in the ``generator`` keyword argument,
@@ -105,7 +104,7 @@ e.g.:
 .. code:: pycon
 
    >>> rhs = generate_ode_function(sym_rhs, q, u, p, generator='cython')
-   >>> rhs(array([1.0, 2.0]), 0.0, array([1.0, 2.0, 3.0]))
+   >>> rhs(np.array([1.0, 2.0]), 0.0, np.array([1.0, 2.0, 3.0]))
    array([ 2., -7.])
 
 The backends are implemented as subclasses of
@@ -117,14 +116,47 @@ make use of the ``ODEFunctionGenerator`` classes directly:
    >>> from pydy.codegen.ode_function_generators import LambdifyODEFunctionGenerator
    >>> g = LambdifyODEFunctionGenerator(sym_rhs, q, u, p)
    >>> rhs = g.generate()
-   >>> rhs(array([1.0, 2.0]), 0.0, array([1.0, 2.0, 3.0]))
+   >>> rhs(np.array([1.0, 2.0]), 0.0, np.array([1.0, 2.0, 3.0]))
    array([ 2., -7.])
 
-Furthermore, for direct control over evaluating matrices you can use the
-``lamdify`` and ``theano_functions`` in SymPy or utilize the
-:py:class:`~pydy.codegen.cython_code.CythonMatrixGenerator` class
-in PyDy. For example, this shows you how to generate C and Cython code to
-evaluate matrices:
+The ordinary differential equation generators also accept the implicit form of
+the equations in two other formats:
+
+.. code:: pycon
+
+   >>> M = sys.eom_method.mass_matrix_full
+   >>> F = sys.eom_method.forcing_full
+   >>> g = LambdifyODEFunctionGenerator(F, q, u, p, mass_matrix=M)
+   >>> rhs = g.generate()
+   >>> rhs(np.array([1.0, 2.0]), 0.0, np.array([1.0, 2.0, 3.0]))
+   array([ 2., -7.])
+
+.. code:: pycon
+
+   >>> from sympy import Matrix
+   >>> M = sys.eom_method.mass_matrix
+   >>> F = sys.eom_method.forcing
+   >>> qd = Matrix([sys.eom_method.kindiffdict()[qi.diff()] for qi in q])
+   >>> g = LambdifyODEFunctionGenerator(F, q, u, p, mass_matrix=M,
+   ...     coordinate_derivatives=qd)
+   >>> rhs = g.generate()
+   >>> rhs(np.array([1.0, 2.0]), 0.0, np.array([1.0, 2.0, 3.0]))
+   array([ 2., -7.])
+
+Additional output equations can also be simulatenously evaluated:
+
+.. code:: pycon
+
+   >>> outputs = Matrix([b.kinetic_energy(sys.eom_method._inertial) for b in sys.eom_method.bodies])
+   >>> g = LambdifyODEFunctionGenerator(sym_rhs, q, u, p, outputs=outputs)
+   >>> rhs = g.generate()
+   >>> rhs(np.array([1.0, 2.0]), 0.0, np.array([1.0, 2.0, 3.0]))
+   array([ 2., -7.]), array([6.0])
+
+Furthermore, for direct control over evaluating matrices you can use
+``lambdify`` in SymPy or utilize the
+:py:class:`~pydy.codegen.cython_code.CythonMatrixGenerator` class in PyDy. For
+example, this shows you how to generate C and Cython code to evaluate matrices:
 
 .. code:: pycon
 

--- a/pydy/codegen/ode_function_generators.py
+++ b/pydy/codegen/ode_function_generators.py
@@ -209,7 +209,7 @@ y : ndarray, shape({num_outputs},)
             [3] M(q, p) u' = F(q, u, t, r, p)
                 q' = G(q, u, t, r, p)
 
-        The function can also optional return additional outputs in the form:
+        The function can also optionally return additional outputs in the form:
 
             y = H(x, t, r, p)
 
@@ -402,8 +402,8 @@ y : ndarray, shape({num_outputs},)
 
     @staticmethod
     def list_syms(indent, syms):
-        """Returns a string representation of a valid rst list of the
-        symbols in the sequence syms and indents the list given the integer
+        """Returns a string representation of a valid reStructuredText list of
+        the symbols in the sequence syms and indents the list given the integer
         number of indentations."""
         indentation = ' ' * indent
         lst = '- ' + ('\n' + indentation + '- ').join([str(s) for s in syms])

--- a/pydy/codegen/ode_function_generators.py
+++ b/pydy/codegen/ode_function_generators.py
@@ -899,9 +899,21 @@ cse : boolean, optional, default True
         f = self._lambdify(outputs)
 
         if self.specifieds is None:
-            self.eval_arrays = lambda q, u, p: np.squeeze(f(q, u, p))
+            if self.outputs is None:
+                self.eval_arrays = lambda q, u, p: np.squeeze(f(q, u, p))
+            else:
+                def wrapper(q, u, p):
+                    xdot, y = f(q, u, p)
+                    return np.squeeze(xdot), np.squeeze(y)
+                self.eval_arrays = wrapper
         else:
-            self.eval_arrays = lambda q, u, r, p: np.squeeze(f(q, u, r, p))
+            if self.outputs is None:
+                self.eval_arrays = lambda q, u, r, p: np.squeeze(f(q, u, r, p))
+            else:
+                def wrapper(q, u, r, p):
+                    xdot, y = f(q, u, r, p)
+                    return np.squeeze(xdot), np.squeeze(y)
+                self.eval_arrays = wrapper
 
     def generate_full_mass_matrix_function(self):
 
@@ -1125,35 +1137,35 @@ cse : boolean, optional, default True
 
         f = self._symjitify(outputs)
 
-        m_dim = len(self.inputs[0]) + len(self.inputs[1])
+        n = self.num_states
 
         if self.specifieds is None:
             if self.outputs is None:
                 def wrapper(q, u, p):
                     all_vals = np.asarray(f.apply(np.hstack((q, u, p))))
-                    m_vals = all_vals[:m_dim*m_dim].reshape(m_dim, m_dim)
-                    f_vals = all_vals[m_dim*m_dim:]
+                    m_vals = all_vals[:n*n].reshape(n, n)
+                    f_vals = all_vals[n*n:]
                     return m_vals, f_vals
             else:
                 def wrapper(q, u, p):
                     all_vals = np.asarray(f.apply(np.hstack((q, u, p))))
-                    m_vals = all_vals[:m_dim*m_dim].reshape(m_dim, m_dim)
-                    f_vals = all_vals[m_dim*m_dim:m_dim*m_dim + self.num_states]
-                    y_vals = all_vals[-self.num_states:]
+                    m_vals = all_vals[:n*n].reshape(n, n)
+                    f_vals = all_vals[n*n:n*n + n]
+                    y_vals = all_vals[n*n + n:]
                     return m_vals, f_vals, y_vals
         else:
             if self.outputs is None:
                 def wrapper(q, u, r, p):
                     all_vals = np.asarray(f.apply(np.hstack((q, u, r, p))))
-                    m_vals = all_vals[:m_dim*m_dim].reshape(m_dim, m_dim)
-                    f_vals = all_vals[m_dim*m_dim:]
+                    m_vals = all_vals[:n*n].reshape(n, n)
+                    f_vals = all_vals[n*n:]
                     return m_vals, f_vals
             else:
                 def wrapper(q, u, r, p):
                     all_vals = np.asarray(f.apply(np.hstack((q, u, r, p))))
-                    m_vals = all_vals[:m_dim*m_dim].reshape(m_dim, m_dim)
-                    f_vals = all_vals[m_dim*m_dim:m_dim*m_dim + self.num_states]
-                    y_vals = all_vals[-self.num_states:]
+                    m_vals = all_vals[:n*n].reshape(n, n)
+                    f_vals = all_vals[n*n:n*n + n]
+                    y_vals = all_vals[n*n + n:]
                     return m_vals, f_vals, y_vals
 
         self.eval_arrays = wrapper

--- a/pydy/codegen/ode_function_generators.py
+++ b/pydy/codegen/ode_function_generators.py
@@ -56,7 +56,7 @@ Parameters
 Returns
 =======
 dx : ndarray, shape({num_states},)
-    The derivative of the state vector.
+    The derivative of the state vector.{outputs_explanation}
 
 """
 
@@ -163,6 +163,12 @@ r : dictionary
 {specified_list}
 """
 
+    _outputs_doc_templates = \
+"""
+y : ndarray, shape({num_outputs},)
+    Values of the provided outputs.
+{output_list}\
+"""
     @staticmethod
     def _deduce_system_type(**kwargs):
         """Based on the combination of arguments this returns which ODE
@@ -191,7 +197,7 @@ r : dictionary
                  mass_matrix=None, coordinate_derivatives=None,
                  specifieds=None, linear_sys_solver='numpy',
                  constants_arg_type=None, specifieds_arg_type=None,
-                 time_first=False):
+                 time_first=False, outputs=None):
         """Generates a numerical function which can evaluate the right hand
         side of the first order ordinary differential equations from a
         system described by one of the following three symbolic forms:
@@ -202,6 +208,10 @@ r : dictionary
 
             [3] M(q, p) u' = F(q, u, t, r, p)
                 q' = G(q, u, t, r, p)
+
+        The function can also optional return additional outputs in the form:
+
+            y = H(x, t, r, p)
 
         where
 
@@ -214,6 +224,7 @@ r : dictionary
             - M : mass matrix (full or minimum)
             - F : right hand side (full or minimum)
             - G : right hand side of the kinematical differential equations
+            - H : output expressions
 
         The generated function is of the form F(x, t, p) or F(x, t, r, p)
         depending on whether the system has specified inputs or not.
@@ -287,6 +298,8 @@ r : dictionary
             By default the argument order of the generated function is ``F(x,
             t, r, p)`` and, if this is set to true, it will be ``F(t, x, r,
             p)``.
+        outputs : sympy.Matrix, shape(o, 1), optional
+            Expressions that are a functions of (q, u, t, r, p).
         """
 
         self.right_hand_side = right_hand_side
@@ -300,6 +313,7 @@ r : dictionary
         self.constants_arg_type = constants_arg_type
         self.specifieds_arg_type = specifieds_arg_type
         self.time_first = time_first
+        self.outputs = outputs
 
         # As the order of the constants and specifieds arguments is not
         # important, allow Sets to be used as input. However, the order must be
@@ -323,6 +337,11 @@ r : dictionary
             self.specifieds_arg_type = None
         else:
             self.num_specifieds = len(specifieds)
+
+        if outputs is not None:
+            self.num_outputs = len(outputs)
+        else:
+            self.num_outputs = 0
 
         # These are pre-allocated storage for the numerical values used in
         # some of the rhs() evaluations.
@@ -487,6 +506,11 @@ r : dictionary
                                 else ''),
             'time_par_after': ('' if self.time_first
                                else self._time_par_template),
+            'outputs_explanation':
+                self._outputs_doc_templates.format(num_outputs=self.num_outputs,
+                    output_list=self.list_syms(8,
+                        me.dynamicsymbols('y0:{}'.format(self.num_outputs))))
+                if self.outputs is not None else '',
         }
 
         if self.specifieds is not None:
@@ -512,6 +536,7 @@ r : dictionary
         x_idx = 1 if self.time_first else 0
 
         if p_arg_type is None and r_arg_type is None:
+
             def rhs(*args):
                 # args: x, t, p
                 # or
@@ -523,10 +548,9 @@ r : dictionary
                 u = args[x_idx][self.num_coordinates:]
 
                 if self.constants:
-                    xdot = self._base_rhs(q, u, *args[2:])
+                    return self._base_rhs(q, u, *args[2:])
                 else:
-                    xdot = self._base_rhs(q, u, *(args[2:3] + ([],)))
-                return xdot
+                    return self._base_rhs(q, u, *(args[2:3] + ([],)))
 
             rhs.__doc__ = self._generate_rhs_docstring()
 
@@ -585,18 +609,27 @@ r : dictionary
         elif (self.system_type == 'full mass matrix' and
               self.linear_sys_solver=='sympy'):
 
-            def base_rhs(*args):
-                M, xdot = self.eval_arrays(*args)
-                return xdot
+            if self.outputs is None:
+                def base_rhs(*args):
+                    M, xdot = self.eval_arrays(*args)
+                    return xdot
+            else:
+                def base_rhs(*args):
+                    M, xdot, y = self.eval_arrays(*args)
+                    return xdot, y
 
             self._base_rhs = base_rhs
 
         elif self.system_type == 'full mass matrix':
 
-            def base_rhs(*args):
-
-                M, F = self.eval_arrays(*args)
-                return self._solve_linear_system(M, F)
+            if self.outputs is None:
+                def base_rhs(*args):
+                    M, F = self.eval_arrays(*args)
+                    return self._solve_linear_system(M, F)
+            else:
+                def base_rhs(*args):
+                    M, F, y = self.eval_arrays(*args)
+                    return self._solve_linear_system(M, F), y
 
             self._base_rhs = base_rhs
 
@@ -605,11 +638,18 @@ r : dictionary
 
             xdot = np.empty(self.num_states, dtype=float)
 
-            def base_rhs(*args):
-                M, udot, qdot = self.eval_arrays(*args)
-                xdot[:self.num_coordinates] = qdot
-                xdot[self.num_coordinates:] = udot
-                return xdot
+            if self.outputs is None:
+                def base_rhs(*args):
+                    M, udot, qdot = self.eval_arrays(*args)
+                    xdot[:self.num_coordinates] = qdot
+                    xdot[self.num_coordinates:] = udot
+                    return xdot
+            else:
+                def base_rhs(*args):
+                    M, udot, qdot, y = self.eval_arrays(*args)
+                    xdot[:self.num_coordinates] = qdot
+                    xdot[self.num_coordinates:] = udot
+                    return xdot, y
 
             self._base_rhs = base_rhs
 
@@ -617,15 +657,26 @@ r : dictionary
 
             xdot = np.empty(self.num_states, dtype=float)
 
-            def base_rhs(*args):
-                M, F, qdot = self.eval_arrays(*args)
-                if self.num_speeds == 1:
-                    udot = F / M
-                else:
-                    udot = self._solve_linear_system(M, F)
-                xdot[:self.num_coordinates] = qdot
-                xdot[self.num_coordinates:] = udot
-                return xdot
+            if self.outputs is None:
+                def base_rhs(*args):
+                    M, F, qdot = self.eval_arrays(*args)
+                    if self.num_speeds == 1:
+                        udot = F / M
+                    else:
+                        udot = self._solve_linear_system(M, F)
+                    xdot[:self.num_coordinates] = qdot
+                    xdot[self.num_coordinates:] = udot
+                    return xdot
+            else:
+                def base_rhs(*args):
+                    M, F, qdot, y = self.eval_arrays(*args)
+                    if self.num_speeds == 1:
+                        udot = F / M
+                    else:
+                        udot = self._solve_linear_system(M, F)
+                    xdot[:self.num_coordinates] = qdot
+                    xdot[self.num_coordinates:] = udot
+                    return xdot, y
 
             self._base_rhs = base_rhs
 
@@ -641,11 +692,11 @@ r : dictionary
         """Returns a function that evaluates the right hand side of the
         first order ordinary differential equations in one of two forms:
 
-            x' = f(x, t, p)
+            x'[, y] = f(x, t, p)
 
             or
 
-            x' = f(x, t, r, p)
+            x'[, y] = f(x, t, r, p)
 
         See the docstring of the generated function for more details.
 
@@ -749,8 +800,11 @@ verbose : boolean, optional, default False
 
         self.define_inputs()
         outputs = [self.right_hand_side]
-
         self._empties = (np.empty(self.num_states, dtype=float),)
+
+        if self.outputs is not None:
+            outputs.append(sm.Matrix(self.outputs))
+            self._empties += (np.empty(len(self.outputs), dtype=float),)
 
         self._set_eval_array(self._cythonize(outputs, self.inputs))
 
@@ -763,6 +817,10 @@ verbose : boolean, optional, default False
         rhs_result = np.empty(self.num_states, dtype=float)
 
         self._empties = (mass_matrix_result, rhs_result)
+
+        if self.outputs is not None:
+            outputs.append(sm.Matrix(self.outputs))
+            self._empties += (np.empty(len(self.outputs), dtype=float),)
 
         if self.linear_sys_solver == 'sympy':
             self._set_eval_array(self._cythonize_symbolic_lusolve(outputs,
@@ -780,6 +838,10 @@ verbose : boolean, optional, default False
         rhs_result = np.empty(self.num_speeds, dtype=float)
         kin_diffs_result = np.empty(self.num_coordinates, dtype=float)
         self._empties = (mass_matrix_result, rhs_result, kin_diffs_result)
+
+        if self.outputs is not None:
+            outputs.append(sm.Matrix(self.outputs))
+            self._empties += (np.empty(len(self.outputs), dtype=float),)
 
         if self.linear_sys_solver == 'sympy':
             self._set_eval_array(self._cythonize_symbolic_lusolve(outputs,
@@ -831,6 +893,8 @@ cse : boolean, optional, default True
 
         self.define_inputs()
         outputs = [self.right_hand_side]
+        if self.outputs is not None:
+            outputs.append(sm.Matrix(self.outputs))
 
         f = self._lambdify(outputs)
 
@@ -843,6 +907,8 @@ cse : boolean, optional, default True
 
         self.define_inputs()
         outputs = [self.mass_matrix, self.right_hand_side]
+        if self.outputs is not None:
+            outputs.append(sm.Matrix(self.outputs))
 
         f = self._lambdify(outputs)
 
@@ -858,6 +924,8 @@ cse : boolean, optional, default True
         self.define_inputs()
         outputs = [self.mass_matrix, self.right_hand_side,
                    self.coordinate_derivatives]
+        if self.outputs is not None:
+            outputs.append(sm.Matrix(self.outputs))
 
         f = self._lambdify(outputs)
 
@@ -872,6 +940,9 @@ cse : boolean, optional, default True
 class TheanoODEFunctionGenerator(ODEFunctionGenerator):
 
     def __init__(self, *args, **kwargs):
+
+        if self.outputs is not None:
+            raise ValueError('Theano generator does not support outputs.')
 
         if theano is None:
             raise ImportError('Theano must be installed to use this class.')
@@ -1018,16 +1089,30 @@ cse : boolean, optional, default True
 
         self.define_inputs()
         outputs = [self.right_hand_side]
+        if self.outputs is not None:
+            outputs.append(sm.Matrix(self.outputs))
 
         f = self._symjitify(outputs)
 
         # NOTE : symjit outputs a list of floats, not a NumPy array of floats.
         if self.specifieds is None:
-            def wrapper(q, u, p):
-                return np.asarray(f.apply(np.hstack((q, u, p))))
+            if self.outputs is None:
+                def wrapper(q, u, p):
+                    return np.asarray(f.apply(np.hstack((q, u, p))))
+            else:
+                def wrapper(q, u, p):
+                    all_vals = np.asarray(f.apply(np.hstack((q, u, p))))
+                    return (all_vals[:self.num_states],
+                            all_vals[self.num_states:])
         else:
-            def wrapper(q, u, r, p):
-                return np.asarray(f.apply(np.hstack((q, u, r, p))))
+            if self.outputs is None:
+                def wrapper(q, u, r, p):
+                    return np.asarray(f.apply(np.hstack((q, u, r, p))))
+            else:
+                def wrapper(q, u, r, p):
+                    all_vals = np.asarray(f.apply(np.hstack((q, u, r, p))))
+                    return (all_vals[:self.num_states],
+                            all_vals[self.num_states:])
 
         self.eval_arrays = wrapper
 
@@ -1035,23 +1120,41 @@ cse : boolean, optional, default True
 
         self.define_inputs()
         outputs = [self.mass_matrix, self.right_hand_side]
+        if self.outputs is not None:
+            outputs.append(sm.Matrix(self.outputs))
 
         f = self._symjitify(outputs)
 
         m_dim = len(self.inputs[0]) + len(self.inputs[1])
 
         if self.specifieds is None:
-            def wrapper(q, u, p):
-                all_vals = np.asarray(f.apply(np.hstack((q, u, p))))
-                m_vals = all_vals[:m_dim*m_dim].reshape(m_dim, m_dim)
-                f_vals = all_vals[m_dim*m_dim:]
-                return m_vals, f_vals
+            if self.outputs is None:
+                def wrapper(q, u, p):
+                    all_vals = np.asarray(f.apply(np.hstack((q, u, p))))
+                    m_vals = all_vals[:m_dim*m_dim].reshape(m_dim, m_dim)
+                    f_vals = all_vals[m_dim*m_dim:]
+                    return m_vals, f_vals
+            else:
+                def wrapper(q, u, p):
+                    all_vals = np.asarray(f.apply(np.hstack((q, u, p))))
+                    m_vals = all_vals[:m_dim*m_dim].reshape(m_dim, m_dim)
+                    f_vals = all_vals[m_dim*m_dim:m_dim*m_dim + self.num_states]
+                    y_vals = all_vals[-self.num_states:]
+                    return m_vals, f_vals, y_vals
         else:
-            def wrapper(q, u, r, p):
-                all_vals = np.asarray(f.apply(np.hstack((q, u, r, p))))
-                m_vals = all_vals[:m_dim*m_dim].reshape(m_dim, m_dim)
-                f_vals = all_vals[m_dim*m_dim:]
-                return m_vals, f_vals
+            if self.outputs is None:
+                def wrapper(q, u, r, p):
+                    all_vals = np.asarray(f.apply(np.hstack((q, u, r, p))))
+                    m_vals = all_vals[:m_dim*m_dim].reshape(m_dim, m_dim)
+                    f_vals = all_vals[m_dim*m_dim:]
+                    return m_vals, f_vals
+            else:
+                def wrapper(q, u, r, p):
+                    all_vals = np.asarray(f.apply(np.hstack((q, u, r, p))))
+                    m_vals = all_vals[:m_dim*m_dim].reshape(m_dim, m_dim)
+                    f_vals = all_vals[m_dim*m_dim:m_dim*m_dim + self.num_states]
+                    y_vals = all_vals[-self.num_states:]
+                    return m_vals, f_vals, y_vals
 
         self.eval_arrays = wrapper
 
@@ -1060,25 +1163,47 @@ cse : boolean, optional, default True
         self.define_inputs()
         outputs = [self.mass_matrix, self.right_hand_side,
                    self.coordinate_derivatives]
+        if self.outputs is not None:
+            outputs.append(sm.Matrix(self.outputs))
 
         f = self._symjitify(outputs)
 
-        m_dim = len(self.inputs[1])
+        m_dim = self.num_speeds
+        f_dim = self.num_speeds
+        k_dim = self.num_coordinates
 
         if self.specifieds is None:
-            def convert_symjit_output(q, u, p):
-                all_vals = np.asarray(f.apply(np.hstack((q, u, p))))
-                m_vals = all_vals[:m_dim*m_dim].reshape(m_dim, m_dim)
-                f_vals = all_vals[m_dim*m_dim:m_dim*m_dim + m_dim]
-                k_vals = all_vals[m_dim*m_dim + m_dim:]
-                return m_vals, f_vals, k_vals
+            if self.outputs is None:
+                def convert_symjit_output(q, u, p):
+                    all_vals = np.asarray(f.apply(np.hstack((q, u, p))))
+                    m_vals = all_vals[:m_dim*m_dim].reshape(m_dim, m_dim)
+                    f_vals = all_vals[m_dim*m_dim:m_dim*m_dim + f_dim]
+                    k_vals = all_vals[m_dim*m_dim + f_dim:]
+                    return m_vals, f_vals, k_vals
+            else:
+                def convert_symjit_output(q, u, p):
+                    all_vals = np.asarray(f.apply(np.hstack((q, u, p))))
+                    m_vals = all_vals[:m_dim*m_dim].reshape(m_dim, m_dim)
+                    f_vals = all_vals[m_dim*m_dim:m_dim*m_dim + f_dim]
+                    k_vals = all_vals[m_dim*m_dim + f_dim:m_dim*m_dim + f_dim + k_dim]
+                    y_vals = all_vals[m_dim*m_dim + m_dim + k_dim:]
+                    return m_vals, f_vals, k_vals, y_vals
         else:
-            def convert_symjit_output(q, u, r, p):
-                all_vals = np.asarray(f.apply(np.hstack((q, u, r, p))))
-                m_vals = all_vals[:m_dim*m_dim].reshape(m_dim, m_dim)
-                f_vals = all_vals[m_dim*m_dim:m_dim*m_dim + m_dim]
-                k_vals = all_vals[m_dim*m_dim + m_dim:]
-                return m_vals, f_vals, k_vals
+            if self.outputs is None:
+                def convert_symjit_output(q, u, r, p):
+                    all_vals = np.asarray(f.apply(np.hstack((q, u, r, p))))
+                    m_vals = all_vals[:m_dim*m_dim].reshape(m_dim, m_dim)
+                    f_vals = all_vals[m_dim*m_dim:m_dim*m_dim + f_dim]
+                    k_vals = all_vals[m_dim*m_dim + f_dim:]
+                    return m_vals, f_vals, k_vals
+            else:
+                def convert_symjit_output(q, u, r, p):
+                    all_vals = np.asarray(f.apply(np.hstack((q, u, r, p))))
+                    m_vals = all_vals[:m_dim*m_dim].reshape(m_dim, m_dim)
+                    f_vals = all_vals[m_dim*m_dim:m_dim*m_dim + f_dim]
+                    k_vals = all_vals[m_dim*m_dim + f_dim:m_dim*m_dim + f_dim + k_dim]
+                    y_vals = all_vals[m_dim*m_dim + f_dim + k_dim:]
+                    return m_vals, f_vals, k_vals, y_vals
 
         self.eval_arrays = convert_symjit_output
 

--- a/pydy/codegen/tests/test_ode_function_generator.py
+++ b/pydy/codegen/tests/test_ode_function_generator.py
@@ -123,7 +123,21 @@ def test_outputs():
                            dict(zip(x, x_vals))).xreplace(
                                (dict(zip(p, p_vals)))).evalf()[:], dtype=float)
 
-    for generator in ('lambdify', 'cython', 'symjit'):
+    generators = ['lambdify']
+    try:
+        import Cython
+    except ImportError:
+        pass
+    else:
+        generators.append('cython')
+    try:
+        import symjit
+    except ImportError:
+        pass
+    else:
+        generators.append('symjit')
+
+    for generator in generators:
         rhs = generate_ode_function(
             forcing,
             kane.q[:],

--- a/pydy/codegen/tests/test_ode_function_generator.py
+++ b/pydy/codegen/tests/test_ode_function_generator.py
@@ -28,6 +28,119 @@ from ...utils import PyDyImportWarning
 warnings.simplefilter('once', PyDyImportWarning)
 
 
+def test_outputs():
+    m1, m2, l1, l2, c, g = sm.symbols('m1, m2, l1, l2, c, g')
+    q1, q2, u1, u2, T1, T2 = me.dynamicsymbols('q1, q2, u1, u2, T1, T2')
+    u3, u4 = me.dynamicsymbols('u3, u4')
+
+    N = me.ReferenceFrame('N')
+    A = me.ReferenceFrame('A')
+    B = me.ReferenceFrame('B')
+
+    A.orient_axis(N, q1, N.z)
+    B.orient_axis(N, q2, N.z)
+    A.set_ang_vel(N, u1*N.z)
+    B.set_ang_vel(N, u2*N.z)
+
+    O = me.Point('O')
+    P1 = O.locatenew('P1', -l1*A.y)
+    P2 = P1.locatenew('P2', -l2*B.y)
+
+    O.set_vel(N, 0)
+    P1.v2pt_theory(O, N, A)
+    P1.set_vel(N, P1.vel(N) - u3*A.y)
+    P2.v2pt_theory(P1, N, B)
+    P2.set_vel(N, P2.vel(N) - u4*B.y)
+
+    bob1 = me.Particle('bob1', P1, m1)
+    bob2 = me.Particle('bob2', P2, m2)
+
+    loads = (
+        (P1, -m1*g*N.y + T1*A.y - T2*B.y),
+        (P2, -m2*g*N.y + T2*B.y),
+        (A, -c*u1*N.z + c*(u2 - u1)*N.z),
+        (B, - c*(u2 - u1)*N.z),
+    )
+
+    kane = me.KanesMethod(
+        N,
+        (q1, q2),
+        (u1, u2),
+        kd_eqs=[q1.diff() - u1, q2.diff() - u2],
+        bodies=(bob1, bob2),
+        forcelist=loads,
+        u_auxiliary=(u3, u4),
+    )
+    kane.kanes_equations()
+
+    qdot = sm.Matrix([u1, u2])
+
+    # augment the mass matrix for noncontributing forces
+    u = sm.Matrix([u1, u2])
+    lam = sm.Matrix([T1, T2])
+    int_of_lam = sm.Matrix([me.dynamicsymbols('I_{T1}, I_{T2}')])
+    x = u.diff().col_join(lam)
+
+    aux_eqs = kane.auxiliary_eqs
+    MuMj = aux_eqs.jacobian(x)  # [Mu Mj]
+    Fa = -aux_eqs.xreplace({fi: 0 for fi in x})  # [Fa]
+    Md = kane.mass_matrix
+    Mz = sm.zeros(Md.shape[0], len(lam))
+    mass_matrix = Md.row_join(Mz).col_join(MuMj)
+    Fd = kane.forcing
+    forcing = Fd.col_join(Fa)
+
+    # extra outputs
+    p1_x, p1_y, p1_z = P1.pos_from(O).to_matrix(N)
+    p2_x, p2_y, p2_z = P2.pos_from(O).to_matrix(N)
+    constraint = P2.pos_from(O).dot(N.x) - sm.sin(2*sm.pi)
+    kinetic_energy = (m1/2*P1.vel(N).dot(P1.vel(N)) +
+                      m2/2*P2.vel(N).dot(P2.vel(N))).xreplace({u3: 0, u4: 0})
+    potential_energy = m1*g*p1_y + m2*g*p2_y
+    outputs = sm.Matrix([
+        p1_x,
+        p1_y,
+        p2_x,
+        p2_y,
+        kinetic_energy,
+        potential_energy,
+        constraint,
+    ])
+
+    x = sm.Matrix((q1, q2, u1, u2, int_of_lam[0], int_of_lam[1]))
+    p = sm.Matrix((m1, m2, l1, l2, c, g))
+
+    t_val = 1.2
+    x_vals = np.deg2rad([3.0, -4.0, -20.0, 10.0, 0.0, 0.0])
+    p_vals = np.array([1.0, 2.0, 3.0, 4.0, 10.0, 9.81])
+
+    qdot_exp = list(x_vals[2:4])
+    udot_exp = np.array(mass_matrix.cramer_solve(forcing).xreplace(
+        dict(zip(x, x_vals))).xreplace((dict(zip(p, p_vals)))).evalf()[:],
+        dtype=float)
+    y_exp = np.array(sm.Matrix((p1_x, p1_y, p2_x, p2_y, kinetic_energy,
+                       potential_energy, constraint,)).xreplace(
+                           dict(zip(x, x_vals))).xreplace(
+                               (dict(zip(p, p_vals)))).evalf()[:], dtype=float)
+
+    for generator in ('lambdify', 'cython', 'symjit'):
+        rhs = generate_ode_function(
+            forcing,
+            kane.q[:],
+            kane.u[:] + int_of_lam[:],
+            mass_matrix=mass_matrix,
+            coordinate_derivatives=qdot,
+            constants=p[:],
+            outputs=outputs,
+            generator=generator,
+        )
+        xdot, y = rhs(x_vals, t_val, p_vals)
+        np.testing.assert_allclose(np.hstack((qdot_exp, udot_exp)), xdot)
+        np.testing.assert_allclose(y_exp, y)
+
+    print(rhs.__doc__)
+
+
 def test_ccontiguous():
 
     x1, x2, v1, v2 = me.dynamicsymbols('x1, x2, v1, v2')
@@ -235,6 +348,8 @@ time_first : boolean, optional
     By default the argument order of the generated function is ``F(x,
     t, r, p)`` and, if this is set to true, it will be ``F(t, x, r,
     p)``.
+outputs : sympy.Matrix, shape(o, 1), optional
+    Expressions that are a functions of (q, u, t, r, p).
 generator : string or ODEFunctionGenerator, optional
     The method used for generating the numeric right hand side. The string
     options are ``{'lambdify'|'theano'|'cython'|'symjit'}`` with ``lambdify``

--- a/pydy/codegen/tests/test_ode_function_generator.py
+++ b/pydy/codegen/tests/test_ode_function_generator.py
@@ -115,7 +115,7 @@ def test_outputs():
     p_vals = np.array([1.0, 2.0, 3.0, 4.0, 10.0, 9.81])
 
     qdot_exp = list(x_vals[2:4])
-    udot_exp = np.array(mass_matrix.cramer_solve(forcing).xreplace(
+    udot_exp = np.array(mass_matrix.LUsolve(forcing).xreplace(
         dict(zip(x, x_vals))).xreplace((dict(zip(p, p_vals)))).evalf()[:],
         dtype=float)
     y_exp = np.array(sm.Matrix((p1_x, p1_y, p2_x, p2_y, kinetic_energy,
@@ -534,6 +534,11 @@ class TestODEFunctionGenerator(object):
                                               self.sys.coordinates,
                                               self.sys.speeds,
                                               self.sys.constants_symbols)
+        self.outputs = sm.Matrix([
+            b.kinetic_energy(self.sys.eom_method._inertial)
+            for b in self.sys.eom_method.bodies
+        ])
+
 
     def test_init_full_rhs(self):
 
@@ -577,6 +582,16 @@ class TestODEFunctionGenerator(object):
         assert g.num_speeds == 2
         assert g.num_states == 4
         assert g.system_type == 'min mass matrix'
+
+    def test_init_outputs(self):
+
+        g = ODEFunctionGenerator(self.rhs,
+                                 self.sys.coordinates,
+                                 self.sys.speeds,
+                                 self.sys.constants_symbols,
+                                 outputs=self.outputs)
+
+        assert g.num_outputs == 2
 
     def test_set_linear_system_solver(self):
 
@@ -666,8 +681,12 @@ class TestODEFunctionGeneratorSubclasses(object):
         # Best keep these in order, otherwise it may change between SymPy
         # versions.
         self.constants = list(sm.ordered(self.sys.constants_symbols))
+        self.outputs = sm.Matrix([
+            b.kinetic_energy(self.sys.eom_method._inertial)
+            for b in self.sys.eom_method.bodies
+        ])
 
-    def eval_rhs(self, rhs):
+    def eval_rhs(self, rhs, with_outputs=False):
 
         # In order:
         c0 = 1.0
@@ -677,9 +696,13 @@ class TestODEFunctionGeneratorSubclasses(object):
         x0 = 1.0
         v0 = 2.0
 
-        xdot = rhs(np.array([x0, v0]), 0.0, np.array([c0, k0, m0]))
-
         expected_xdot = np.array([v0, (-c0 * v0 - k0 * x0) / m0])
+
+        if with_outputs:
+            xdot, y = rhs(np.array([x0, v0]), 0.0, np.array([c0, k0, m0]))
+            np.testing.assert_allclose(y, [m0*v0**2/2])
+        else:
+            xdot = rhs(np.array([x0, v0]), 0.0, np.array([c0, k0, m0]))
 
         np.testing.assert_allclose(xdot, expected_xdot)
 
@@ -794,6 +817,59 @@ class TestODEFunctionGeneratorSubclasses(object):
                 xdot = f(x, 0.0, r, p)
 
                 np.testing.assert_allclose(xdot, expected)
+
+    def test_generate_full_rhs_with_outputs(self):
+
+        rhs = self.sys.eom_method.rhs()
+
+        for Subclass in self.ode_function_subclasses:
+
+            g = Subclass(rhs,
+                         self.sys.coordinates,
+                         self.sys.speeds,
+                         self.constants,
+                         outputs=self.outputs)
+
+            rhs_func = g.generate()
+
+            self.eval_rhs(rhs_func, with_outputs=True)
+
+    def test_generate_full_mass_matrix_with_outputs(self):
+
+        for Subclass in self.ode_function_subclasses:
+
+            g = Subclass(self.sys.eom_method.forcing_full,
+                         self.sys.coordinates,
+                         self.sys.speeds,
+                         self.constants,
+                         mass_matrix=self.sys.eom_method.mass_matrix_full,
+                         outputs=self.outputs)
+
+            rhs_func = g.generate()
+
+            print(self.outputs)
+
+            self.eval_rhs(rhs_func, with_outputs=True)
+
+    def test_generate_min_mass_matrix_with_outputs(self):
+
+        kin_diff_eqs = self.sys.eom_method.kindiffdict()
+        coord_derivs = sm.Matrix([kin_diff_eqs[c.diff()] for c in
+                                  self.sys.coordinates])
+
+        for Subclass in self.ode_function_subclasses:
+
+            g = Subclass(self.sys.eom_method.forcing,
+                         self.sys.coordinates,
+                         self.sys.speeds,
+                         self.constants,
+                         mass_matrix=self.sys.eom_method.mass_matrix,
+                         coordinate_derivatives=coord_derivs,
+                         outputs=self.outputs)
+
+            rhs_func = g.generate()
+
+            self.eval_rhs(rhs_func, with_outputs=True)
 
     def test_rhs_args(self):
         # This test takes a while to run but it checks all the combinations.

--- a/pydy/codegen/tests/test_ode_function_generator.py
+++ b/pydy/codegen/tests/test_ode_function_generator.py
@@ -152,7 +152,20 @@ def test_outputs():
         np.testing.assert_allclose(np.hstack((qdot_exp, udot_exp)), xdot)
         np.testing.assert_allclose(y_exp, y)
 
-    print(rhs.__doc__)
+    expected_end = \
+"""\
+y : ndarray, shape(7,)
+    Values of the provided outputs.
+        - y0(t)
+        - y1(t)
+        - y2(t)
+        - y3(t)
+        - y4(t)
+        - y5(t)
+        - y6(t)
+
+"""
+    assert rhs.__doc__.endswith(expected_end)
 
 
 def test_ccontiguous():


### PR DESCRIPTION
Fixes #136
Fixes #338

A new kwarg that accepts a column matrix of expressions that are functions of the coordinates, speeds, constants, and specifieds enables code generation of these output expressions alongside the expressions for evaluating the state derivatives. These output computations share common subexpressions and thus evaluate efficiently when both the state derivatives and the outputs are required.

TODO

- [x] Update docs page with examples of using outputs.
- [x] Consider supporting output groups, i.e. `xdot, y1, y2, y3 = rhs()`.
- [x] Consider letting the user define symbols for names of the outputs.
- [x] Add test for rhs docstring for outputs.