### PR TITLE
docs: add 3D N-body example to table

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -89,7 +89,9 @@ Table of Contents
              :target: examples/rocket-car.html
 
              Nonholonomic Rocket Car.
-        -
+        - :doc:`examples/3d-n-body-pendulum`
+
+          3D N-body pendulum with elastic collisions.
 
 Indices and tables
 ==================


### PR DESCRIPTION
## Summary
- fill the empty examples table cell with the existing 3D N-body pendulum example
- add a short description for the example's elastic collision content

Closes #601.

## Tests
- `PYTHONUTF8=1 python -m pip install -e ".[doc]"`
- `PYTHONUTF8=1 python -m pip install -e ".[examples]"`
- `python -m pip install Cython`
- `PYTHONUTF8=1 python -m sphinx -b html docs docs\_build\html`
