### PR TITLE
Separate holonomic and nonholonomic constraints in System.

### DIFF
--- a/pydy/system.py
+++ b/pydy/system.py
@@ -163,7 +163,8 @@ from scipy.integrate import odeint
 from scipy.optimize import root
 
 from .codegen.ode_function_generators import generate_ode_function
-from .utils import PyDyFutureWarning, PyDyUserWarning
+from .utils import (PyDyFutureWarning, PyDyUserWarning,
+                    _sort_velocity_constraints)
 
 SYMPY_VERSION = sm.__version__
 
@@ -949,25 +950,51 @@ class System(object):
         return kwargs
 
     def _extract_constraints(self):
-        """Extracts the configuration and motion constraints from the
-        eom_method and stores them in attributes."""
+        """Extracts the configuration, nonholonomic, and motion constraints
+        from the eom_method and stores them in attributes."""
 
         if self.eom_method._f_h:
             self.config_constraints = self.eom_method._f_h
         else:
             self.config_constraints = sm.Matrix([])
 
+        self._num_config_constraints = len(self.config_constraints)
+
         if self.eom_method._k_nh:
-            # rebuild the nonholonomic constraints from KanesMethod
             # TODO : KanesMethod and _Method should store the original
             # constraints passed by the user. Fix in sympy.physics.mechanics!
-            self.motion_constraints = (
+
+            # rebuild the velocity constraints from KanesMethod, note that
+            # these can include time differentiated holonomic constraints
+            velocity_constraints = (
                 self.eom_method._k_nh*self.eom_method.u +
                 self.eom_method._f_nh)
+
+            self.motion_constraints = velocity_constraints
+
+            if self.config_constraints:
+                h_idxs, nh_idxs = _sort_velocity_constraints(
+                    velocity_constraints,
+                    self.coordinates[:],
+                    list(self.eom_method.kindiffdict().values()))
+
+                if len(h_idxs) != self.num_config_constraints:
+                    raise ValueError('There should be the same number of time'
+                                    ' differentiated holonomic constraints '
+                                    ' present in the velocity constraints to '
+                                    ' that of the holonomic constraints.')
+                if len(nh_idxs) == 0:
+                    self.nonholonomic_constraints = sm.Matrix([])
+                else:
+                    self.nonholonomic_constraints = sm.Matrix(
+                        velocity_constraints)[nh_idxs, 0]
+            else:
+                self.nonholonomic_constraints = velocity_constraints
         else:
             self.motion_constraints = sm.Matrix([])
+            self.nonholonomic_constraints = sm.Matrix([])
 
-        self._num_config_constraints = len(self.config_constraints)
+        self._num_nonholonomic_constraints = len(self.nonholonomic_constraints)
         self._num_motion_constraints = len(self.motion_constraints)
 
     @property
@@ -976,32 +1003,38 @@ class System(object):
         return self._num_config_constraints
 
     @property
+    def num_nonholonomic_constraints(self):
+        """Number of nonholonomic constraints."""
+        return self._num_nonholonomic_constraints
+
+    @property
     def num_motion_constraints(self):
         """Number of motion constraints."""
         return self._num_motion_constraints
 
     @property
     def constraints(self):
-        """A column matrix of configuration and motion constraints expressions,
-        ordered as stored in
+        """A column matrix of configuration and nonholonomic constraints
+        expressions, ordered as stored in
         :external+sympy:py:class:~sympy.physics.mechanics.kane.KanesMethod."""
         constraints = sm.Matrix([])
 
-        if self.config_constraints or self.motion_constraints:
+        if self.config_constraints or self.nonholonomic_constraints:
             if self.config_constraints:
                 constraints = self.config_constraints
 
-            if constraints and self.motion_constraints:
-                constraints = constraints.col_join(self.motion_constraints)
+            if constraints and self.nonholonomic_constraints:
+                constraints = constraints.col_join(
+                    self.nonholonomic_constraints)
             else:
-                constraints = self.motion_constraints
+                constraints = self.nonholonomic_constraints
 
         return constraints
 
     @property
     def num_constraints(self):
-        """Total number of configuration and motion constaints."""
-        return self.num_config_constraints + self.num_motion_constraints
+        """Total number of configuration and nonholonomic constaints."""
+        return self.num_config_constraints + self.num_nonholonomic_constraints
 
     def set_dependent_initial_conditions(self, dep_vars=None, use_jac=False,
                                          **root_kwargs):
@@ -1034,16 +1067,20 @@ class System(object):
             raise ValueError(msg)
         else:
             num_holo = self.num_config_constraints
-            num_nonh = self.num_motion_constraints
+            num_nonh = self.num_nonholonomic_constraints
 
         # TODO : These variables should be publicly accessible on KanesMethod.
+        # NOTE : If there are holonomic constraints, then you have to solve for
+        # both the dependent coordinate and dependent speed associated with
+        # this constraint, i.e. the time differentiated holoomic constraints is
+        # treated as a nonholonomic constraint.
         if dep_vars is None:
             dep_vars = self.eom_method._qdep[:] + self.eom_method._udep[:]
 
         # TODO : Would be nice to check if the dependent variables are present
         # in the constraints and that the right number of coordinates and
         # speeds are each supplied.
-        if len(dep_vars) != self.num_constraints:
+        if len(dep_vars) != (2*num_holo + num_nonh):
             msg = (f'You must supply {num_holo} dependent coordinates and '
                    f'{num_nonh} dependent speeds.')
             raise ValueError(msg)
@@ -1055,21 +1092,30 @@ class System(object):
         dep_guess = [x0_dict[xi] for xi in dep_vars]
         dep_idxs = [self.states.index(xi) for xi in dep_vars]
 
+        # NOTE : M + (M + m) equations.
+        # TODO : Create a ._evaluate_all_constraints() method for this.
+        constraints = self.config_constraints.col_join(
+            self.motion_constraints)
+
         if use_jac:
-            jac = self.constraints.jacobian(dep_vars)
-            eval_jac = sm.lambdify((self.states, self.constants_symbols), jac,
-                                   cse=True)
+            jac = constraints.jacobian(dep_vars)
+            eval_jac = sm.lambdify((self.states, self.constants_symbols),
+                                   (constraints, jac), cse=True)
 
             def eval_f(x_dep, p):
                 x[dep_idxs] = x_dep
-                return self.evaluate_constraints(x=x), eval_jac(x, p)
+                con_vals, jac_vals = eval_jac(x, p)
+                return con_vals.squeeze(), jac_vals
 
             fprime = True
         else:
+            # TODO : Create a ._evaluate_all_constraints() method for this.
+            eval_con = sm.lambdify((self.states, self.constants_symbols),
+                                   constraints, cse=True)
 
             def eval_f(x_dep, p):
                 x[dep_idxs] = x_dep
-                return self.evaluate_constraints(x=x)
+                return eval_con(x, p).squeeze()
 
             fprime = False
 

--- a/pydy/system.py
+++ b/pydy/system.py
@@ -954,11 +954,11 @@ class System(object):
         from the eom_method and stores them in attributes."""
 
         if self.eom_method._f_h:
-            self.config_constraints = self.eom_method._f_h
+            self.holonomic_constraints = self.eom_method._f_h
         else:
-            self.config_constraints = sm.Matrix([])
+            self.holonomic_constraints = sm.Matrix([])
 
-        self._num_config_constraints = len(self.config_constraints)
+        self._num_holonomic_constraints = len(self.holonomic_constraints)
 
         if self.eom_method._k_nh:
             # TODO : KanesMethod and _Method should store the original
@@ -970,15 +970,15 @@ class System(object):
                 self.eom_method._k_nh*self.eom_method.u +
                 self.eom_method._f_nh)
 
-            self.motion_constraints = velocity_constraints
+            self.velocity_constraints = velocity_constraints
 
-            if self.config_constraints:
+            if self.holonomic_constraints:
                 h_idxs, nh_idxs = _sort_velocity_constraints(
                     velocity_constraints,
                     self.coordinates[:],
                     list(self.eom_method.kindiffdict().values()))
 
-                if len(h_idxs) != self.num_config_constraints:
+                if len(h_idxs) != self.num_holonomic_constraints:
                     raise ValueError('There should be the same number of time'
                                     ' differentiated holonomic constraints '
                                     ' present in the velocity constraints to '
@@ -991,16 +991,16 @@ class System(object):
             else:
                 self.nonholonomic_constraints = velocity_constraints
         else:
-            self.motion_constraints = sm.Matrix([])
+            self.velocity_constraints = sm.Matrix([])
             self.nonholonomic_constraints = sm.Matrix([])
 
         self._num_nonholonomic_constraints = len(self.nonholonomic_constraints)
-        self._num_motion_constraints = len(self.motion_constraints)
+        self._num_velocity_constraints = len(self.velocity_constraints)
 
     @property
-    def num_config_constraints(self):
+    def num_holonomic_constraints(self):
         """Number of configuration constraints."""
-        return self._num_config_constraints
+        return self._num_holonomic_constraints
 
     @property
     def num_nonholonomic_constraints(self):
@@ -1008,9 +1008,9 @@ class System(object):
         return self._num_nonholonomic_constraints
 
     @property
-    def num_motion_constraints(self):
+    def num_velocity_constraints(self):
         """Number of motion constraints."""
-        return self._num_motion_constraints
+        return self._num_velocity_constraints
 
     @property
     def constraints(self):
@@ -1019,9 +1019,9 @@ class System(object):
         :external+sympy:py:class:~sympy.physics.mechanics.kane.KanesMethod."""
         constraints = sm.Matrix([])
 
-        if self.config_constraints or self.nonholonomic_constraints:
-            if self.config_constraints:
-                constraints = self.config_constraints
+        if self.holonomic_constraints or self.nonholonomic_constraints:
+            if self.holonomic_constraints:
+                constraints = self.holonomic_constraints
 
             if constraints and self.nonholonomic_constraints:
                 constraints = constraints.col_join(
@@ -1034,7 +1034,7 @@ class System(object):
     @property
     def num_constraints(self):
         """Total number of configuration and nonholonomic constaints."""
-        return self.num_config_constraints + self.num_nonholonomic_constraints
+        return self.num_holonomic_constraints + self.num_nonholonomic_constraints
 
     def set_dependent_initial_conditions(self, dep_vars=None, use_jac=False,
                                          **root_kwargs):
@@ -1066,7 +1066,7 @@ class System(object):
                    'conditions yourself.')
             raise ValueError(msg)
         else:
-            num_holo = self.num_config_constraints
+            num_holo = self.num_holonomic_constraints
             num_nonh = self.num_nonholonomic_constraints
 
         # TODO : These variables should be publicly accessible on KanesMethod.
@@ -1094,8 +1094,8 @@ class System(object):
 
         # NOTE : M + (M + m) equations.
         # TODO : Create a ._evaluate_all_constraints() method for this.
-        constraints = self.config_constraints.col_join(
-            self.motion_constraints)
+        constraints = self.holonomic_constraints.col_join(
+            self.velocity_constraints)
 
         if use_jac:
             jac = constraints.jacobian(dep_vars)
@@ -1443,7 +1443,7 @@ class System(object):
                 con[i, :] = y[self._constraint_idxs]
             return con
 
-    def evaluate_config_constraints(self, x=None, t=None):
+    def evaluate_holonomic_constraints(self, x=None, t=None):
         """Returns the values of the configuration at the initial condition or,
         alternatively, for the provided state vector.
 
@@ -1474,15 +1474,15 @@ class System(object):
             help(rhs)
 
         """
-        if self.num_config_constraints == 0:
+        if self.num_holonomic_constraints == 0:
             raise ValueError('This system has no configuration constraints.')
         con = self.evaluate_constraints(x=x, t=t)
         if len(con.shape) == 1:
-            return con[:self.num_config_constraints]
+            return con[:self.num_holonomic_constraints]
         else:
-            return con[:, :self.num_config_constraints]
+            return con[:, :self.num_holonomic_constraints]
 
-    def evaluate_motion_constraints(self, x=None, t=None):
+    def evaluate_velocity_constraints(self, x=None, t=None):
         """Returns the values of the motion at the initial condition or,
         alternatively, for the provided state vector.
 
@@ -1513,13 +1513,13 @@ class System(object):
             help(rhs)
 
         """
-        if self.num_motion_constraints == 0:
+        if self.num_velocity_constraints == 0:
             raise ValueError('This system has no motion constraints.')
         con = self.evaluate_constraints(x=x, t=t)
         if len(con.shape) == 1:
-            return con[self.num_config_constraints:]
+            return con[self.num_holonomic_constraints:]
         else:
-            return con[:, self.num_config_constraints:]
+            return con[:, self.num_holonomic_constraints:]
 
     def integrate(self, **solver_kwargs):
         """Integrates the equations

--- a/pydy/system.py
+++ b/pydy/system.py
@@ -1016,7 +1016,7 @@ class System(object):
     def constraints(self):
         """A column matrix of configuration and nonholonomic constraints
         expressions, ordered as stored in
-        :external+sympy:py:class:~sympy.physics.mechanics.kane.KanesMethod."""
+        :external+sympy:py:class:`~sympy.physics.mechanics.kane.KanesMethod`."""
         constraints = sm.Matrix([])
 
         if self.holonomic_constraints or self.nonholonomic_constraints:
@@ -1034,7 +1034,8 @@ class System(object):
     @property
     def num_constraints(self):
         """Total number of configuration and nonholonomic constaints."""
-        return self.num_holonomic_constraints + self.num_nonholonomic_constraints
+        return (self.num_holonomic_constraints +
+                self.num_nonholonomic_constraints)
 
     def set_dependent_initial_conditions(self, dep_vars=None, use_jac=False,
                                          **root_kwargs):
@@ -1483,8 +1484,8 @@ class System(object):
             return con[:, :self.num_holonomic_constraints]
 
     def evaluate_velocity_constraints(self, x=None, t=None):
-        """Returns the values of the motion at the initial condition or,
-        alternatively, for the provided state vector.
+        """Returns the values of the velocity constraints at the initial
+        condition or, alternatively, for the provided state vector.
 
         Parameters
         ==========

--- a/pydy/tests/test_system.py
+++ b/pydy/tests/test_system.py
@@ -631,11 +631,13 @@ def test_system_with_constraints(plot=False):
     gravity = (Q, -m*g*N.z)
 
     q = [x, y, yaw, roll, pitch]
-    qdot_exprs = list(sm.solve(kd_eqs, [x.diff(), y.diff(), yaw.diff(), roll.diff(),
-                                   pitch.diff()]).values())
+    qdot_exprs = list(sm.solve(
+        kd_eqs,
+        [x.diff(), y.diff(), yaw.diff(), roll.diff(), pitch.diff()]).values())
     h_idxs, nh_idxs = _sort_velocity_constraints(nonholonomic, q, qdot_exprs)
-    holonomic_constraints = nonholonomic[h_idxs]
-    nonholonomic_constraints = nonholonomic[nh_idxs]
+
+    assert h_idxs == [2]
+    assert nh_idxs == [0, 1]
 
     kane = me.KanesMethod(
         N,
@@ -654,8 +656,9 @@ def test_system_with_constraints(plot=False):
     sys = System(kane)
 
     assert sys.num_config_constraints == 1
+    assert sys.num_nonholonomic_constraints == 2
     assert sys.num_motion_constraints == 3
-    assert sys.num_constraints == 4
+    assert sys.num_constraints == 3
 
     sys.constants = {
         r: 0.3,

--- a/pydy/tests/test_system.py
+++ b/pydy/tests/test_system.py
@@ -16,7 +16,7 @@ symjit = sm.external.import_module('symjit')
 
 from ..system import System
 from ..models import multi_mass_spring_damper, n_link_pendulum_on_cart
-from ..utils import PyDyImportWarning
+from ..utils import PyDyImportWarning, _sort_velocity_constraints
 
 SYMPY_VERSION = sm.__version__
 
@@ -629,6 +629,13 @@ def test_system_with_constraints(plot=False):
     disc = me.RigidBody('disc', Q, C, m, inertia)
 
     gravity = (Q, -m*g*N.z)
+
+    q = [x, y, yaw, roll, pitch]
+    qdot_exprs = list(sm.solve(kd_eqs, [x.diff(), y.diff(), yaw.diff(), roll.diff(),
+                                   pitch.diff()]).values())
+    h_idxs, nh_idxs = _sort_velocity_constraints(nonholonomic, q, qdot_exprs)
+    holonomic_constraints = nonholonomic[h_idxs]
+    nonholonomic_constraints = nonholonomic[nh_idxs]
 
     kane = me.KanesMethod(
         N,

--- a/pydy/tests/test_system.py
+++ b/pydy/tests/test_system.py
@@ -57,11 +57,11 @@ class TestSystem():
         assert sys.initial_conditions == dict()
         assert sys.noncontributing_forces == []
         assert sys.num_auxiliaries == 0
-        assert sys.num_config_constraints == 0
+        assert sys.num_holonomic_constraints == 0
         assert sys.num_constants == 4
         assert sys.num_constraints == 0
         assert sys.num_coordinates == 1
-        assert sys.num_motion_constraints == 0
+        assert sys.num_velocity_constraints == 0
         assert sys.num_outputs == 0
         assert sys.num_specifieds == 1
         assert sys.num_speeds == 1
@@ -432,9 +432,9 @@ class TestSystem():
         with pytest.raises(ValueError):
             self.sys.evaluate_constraints()
         with pytest.raises(ValueError):
-            self.sys.evaluate_config_constraints()
+            self.sys.evaluate_holonomic_constraints()
         with pytest.raises(ValueError):
-            self.sys.evaluate_motion_constraints()
+            self.sys.evaluate_velocity_constraints()
 
     def test_integrate(self):
 
@@ -655,9 +655,9 @@ def test_system_with_constraints(plot=False):
 
     sys = System(kane)
 
-    assert sys.num_config_constraints == 1
+    assert sys.num_holonomic_constraints == 1
     assert sys.num_nonholonomic_constraints == 2
-    assert sys.num_motion_constraints == 3
+    assert sys.num_velocity_constraints == 3
     assert sys.num_constraints == 3
 
     sys.constants = {
@@ -706,9 +706,9 @@ def test_system_with_constraints(plot=False):
     np.testing.assert_allclose(x0[u5], np.deg2rad(100.0))
     np.testing.assert_allclose(x0[u6], speed/sys.constants[r])
 
-    np.testing.assert_allclose(sys.evaluate_config_constraints(), 0.0,
+    np.testing.assert_allclose(sys.evaluate_holonomic_constraints(), 0.0,
                                atol=1e-12)
-    np.testing.assert_allclose(sys.evaluate_motion_constraints(), 0.0,
+    np.testing.assert_allclose(sys.evaluate_velocity_constraints(), 0.0,
                                atol=1e-12)
     np.testing.assert_allclose(sys.evaluate_constraints(), 0.0, atol=1e-12)
 
@@ -784,9 +784,9 @@ def test_system_with_constraints(plot=False):
     np.testing.assert_allclose(x0[u5], np.deg2rad(100.0))
     np.testing.assert_allclose(x0[u6], speed/sys.constants[r])
 
-    np.testing.assert_allclose(sys.evaluate_config_constraints(), 0.0,
+    np.testing.assert_allclose(sys.evaluate_holonomic_constraints(), 0.0,
                                atol=1e-10)
-    np.testing.assert_allclose(sys.evaluate_motion_constraints(), 0.0,
+    np.testing.assert_allclose(sys.evaluate_velocity_constraints(), 0.0,
                                atol=1e-10)
     np.testing.assert_allclose(sys.evaluate_constraints(), 0.0, atol=1e-10)
 
@@ -960,9 +960,9 @@ def test_system_with_noncontributing_forces(plot=False):
     assert sys._simple_outputs_symbols == [T_, fn]
     assert sys.noncontributing_forces == [T1, T2]
     assert sys.constraints == sm.Matrix([mot_con])
-    assert sys.num_config_constraints == 0
+    assert sys.num_holonomic_constraints == 0
     assert sys.num_constraints == 1
-    assert sys.num_motion_constraints == 1
+    assert sys.num_velocity_constraints == 1
     assert sys.num_outputs == 4
     assert sys.outputs_symbols == [T_, fn, T1, T2]
 
@@ -973,10 +973,10 @@ def test_system_with_noncontributing_forces(plot=False):
     np.testing.assert_allclose(sys.evaluate_outputs(),
         [1.151171,  0.0, 30.235328, 18.345324])
 
-    np.testing.assert_allclose(sys.evaluate_motion_constraints(), [0.0])
+    np.testing.assert_allclose(sys.evaluate_velocity_constraints(), [0.0])
     np.testing.assert_allclose(sys.evaluate_constraints(), [0.0])
     with pytest.raises(ValueError):
-        sys.evaluate_config_constraints()
+        sys.evaluate_holonomic_constraints()
 
     ###########################################################################
     # Check that the system will skip automatic parsing of the auxiliary
@@ -1005,9 +1005,9 @@ def test_system_with_noncontributing_forces(plot=False):
     with pytest.raises(ValueError):
         sys.evaluate_constraints()
     with pytest.raises(ValueError):
-        sys.evaluate_config_constraints()
+        sys.evaluate_holonomic_constraints()
     with pytest.raises(ValueError):
-        sys.evaluate_motion_constraints()
+        sys.evaluate_velocity_constraints()
     np.testing.assert_allclose(sys.evaluate_ode(),
                                [0.0, 0.0, 0.0, 0.0])
     np.testing.assert_allclose(sys.evaluate_outputs(),

--- a/pydy/utils.py
+++ b/pydy/utils.py
@@ -6,6 +6,8 @@ import itertools
 
 from packaging.version import parse as parse_version
 import sympy as sm
+import sympy.physics.mechanics as me
+import numpy as np
 
 SYMPY_VERSION = sm.__version__
 
@@ -44,18 +46,17 @@ def _sort_velocity_constraints(velocity_constraints, q, qdot_exprs):
     velocity_constraints = sm.Matrix(velocity_constraints)
     jac, _ = sm.linear_eq_to_matrix(velocity_constraints, qdot_exprs)
     nonholonomic_idxs = []
-    q_perm = itertools.permutations(q, 2)
+    idxs = list(range(len(qdot_exprs)))
+    comb_idxs = itertools.combinations(idxs, 2)
     for i, row in enumerate(jac.tolist()):
-        p = itertools.permutations(row, 2)
-        for dfdqi_pair, q_pair in zip(p, q_perm):
-            zero = sm.trigsimp(dfdqi_pair[0].diff(q_pair[1]) -
-                               dfdqi_pair[1].diff(q_pair[0]))
-            print(zero)
-            if zero != 0:
-                print('not', zero)
+        for (j, k) in comb_idxs:
+            zero = row[j].diff(q[k]) - row[k].diff(q[j])
+            syms = list(zero.atoms(sm.Symbol) | me.find_dynamicsymbols(zero))
+            eval_zero = sm.lambdify(syms, zero)
+            vals = np.random.random(len(syms))
+            if not np.allclose(eval_zero(*vals), 0.0, atol=1e-12):
                 nonholonomic_idxs.append(i)
                 break
-
     all_idxs = range(len(velocity_constraints))
     holonomic_idxs = [i for i in all_idxs if i not in nonholonomic_idxs]
 

--- a/pydy/utils.py
+++ b/pydy/utils.py
@@ -2,11 +2,64 @@
 
 import re
 import textwrap
+import itertools
 
 from packaging.version import parse as parse_version
 import sympy as sm
 
 SYMPY_VERSION = sm.__version__
+
+
+def _sort_velocity_constraints(velocity_constraints, q, qdot_exprs):
+    """Return the time differentiated holonomic constraints and nonholonomic
+    constraints separately.
+
+    Given velcoity leval constraings that may be a combination of time
+    differentiated holonomic constraints and nonholonomic constraints, this
+    function uses the symmetry of second derivatives check to distinguish the
+    constraints.
+
+    If the velocity constraints are large expressions, this could be slow due
+    to the need to simplify for zero checking.
+
+    Parameters
+    ==========
+    velocity_constraints : iterable of Expr
+    q : iterable of Function of time
+        Generalized coordinates.
+    qdot_exprs : iteraable of Expr
+        Expressions for the q' definitions.
+
+    Returns
+    =======
+    holonomic_idxs : list of integer
+        Indices that identify the rows of ``velocity_constraints`` which are
+        time differentiated holonomic constraints.
+    nonholonomic_idxs : list of integer
+        Indices that identify the rows of ``velocity_constraints`` which are
+        nonholonomic constraints.
+
+    """
+    # TODO : This could be something useful to implement in SymPy.
+    velocity_constraints = sm.Matrix(velocity_constraints)
+    jac, _ = sm.linear_eq_to_matrix(velocity_constraints, qdot_exprs)
+    nonholonomic_idxs = []
+    q_perm = itertools.permutations(q, 2)
+    for i, row in enumerate(jac.tolist()):
+        p = itertools.permutations(row, 2)
+        for dfdqi_pair, q_pair in zip(p, q_perm):
+            zero = sm.trigsimp(dfdqi_pair[0].diff(q_pair[1]) -
+                               dfdqi_pair[1].diff(q_pair[0]))
+            print(zero)
+            if zero != 0:
+                print('not', zero)
+                nonholonomic_idxs.append(i)
+                break
+
+    all_idxs = range(len(velocity_constraints))
+    holonomic_idxs = [i for i in all_idxs if i not in nonholonomic_idxs]
+
+    return holonomic_idxs, nonholonomic_idxs
 
 
 def sympy_equal_to_or_newer_than(version, installed_version=None):


### PR DESCRIPTION
Fixes #619 

- Added a numerical method of sorting a set of velocity constraints into time differentiated holonomic and nonholonomic constraints.
- `.constraints` now returns the holonomic constraints stacked on the nonholonomic constraints (strictly).
- `.motion_constraints` renamed to `.velocity_constraints` to match with unified names in SymPy (https://github.com/sympy/sympy/pull/29815).
- `.config_constraints` renamed to `.holonomic_constraints` to match with unified names in SymPy (https://github.com/sympy/sympy/pull/29815).
- `.nonholonomic_constraints` attribute added.