### PR TITLE
Fix constants issue 628

### DIFF
--- a/pydy/system.py
+++ b/pydy/system.py
@@ -159,6 +159,7 @@ from itertools import repeat
 import numpy as np
 import sympy as sm
 from sympy.physics.mechanics import dynamicsymbols, find_dynamicsymbols
+from sympy.core.function import AppliedUndef
 from scipy.integrate import odeint
 from scipy.optimize import root
 
@@ -382,10 +383,19 @@ class System(object):
         return self._constants_symbols
 
     def _check_constants(self, constants):
-        symbols = self.constants_symbols
+        """Ensures provided constants are valid and adds new constant
+        symbols to the system's tracked symbols.
+        """
+        #from sympy.core.function import AppliedUndef
+        #from sympy.physics.mechanics import dynamicsymbols
+
         for k in constants.keys():
-            if k not in symbols:
-                raise ValueError("Symbol {} is not a constant.".format(k))
+            # Reject the time variable and dynamic symbols (functions of time)
+            if k == dynamicsymbols._t or isinstance(k, AppliedUndef):
+                raise ValueError("Symbol {} is not a valid constant.".format(k))
+        
+        # Safely add any new, valid constant keys to the tracked set
+        self._constants_symbols.update(constants.keys())
 
     def _constants_padded_with_defaults(self):
         d = dict(zip(self.constants_symbols, repeat(1.0, self.num_constants)))

--- a/pydy/system.py
+++ b/pydy/system.py
@@ -386,8 +386,6 @@ class System(object):
         """Ensures provided constants are valid and adds new constant
         symbols to the system's tracked symbols.
         """
-        #from sympy.core.function import AppliedUndef
-        #from sympy.physics.mechanics import dynamicsymbols
 
         for k in constants.keys():
             # Reject the time variable and dynamic symbols (functions of time)


### PR DESCRIPTION
### Description
This PR resolves the issue where a user could not add constant symbols to a `System` if those constants were absent from the equations of motion (EoMs) and `constant_symbol` is None.  


i have updated `_check_constants` method .
* **Previously**:- It was just checking  that `self.constant.key()`  is present in ` constant` list or not [whereas `constant` list is provided by user or created using kane]
now :- it just check `self.constant.key()` is valid or not if yes then also update constant list 

### One more problem Solved
Now if user provide incomplte list of `constants_symbols` but complete dict of  `constants` then also system will work perfectly 

### Questions  . 
**Problem** :- What if user provide incomplete list of  `constants_symbols`  and also incomplete dict of `constant` then system will fail
because kane function is only use when user do not provide single constant symbol

**Solution** :-  can we just make mandatory to fetch `constant_symbol` from kane function then we will do dual sync between dict key and constant list


Closes #628